### PR TITLE
workbench: append-only record-amendment overlays (v1-draft)

### DIFF
--- a/ontologies/workbench/v1-draft/workbench.shapes.ttl
+++ b/ontologies/workbench/v1-draft/workbench.shapes.ttl
@@ -20,3 +20,37 @@ workbench:ImportedConversationShape a sh:NodeShape ;
     sh:targetClass workbench:ImportedConversation ;
     sh:property [ sh:path workbench:conversationSource ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:rawContentLocation ; sh:minCount 1 ; sh:datatype xsd:string ] .
+
+# ── Append-only record amendment overlays (v1-draft.0.2) ────────────────────
+
+workbench:AmendmentShape a sh:NodeShape ;
+    sh:targetClass workbench:Amendment ;
+    sh:property [ sh:path workbench:amendsRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:amendsProperty ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:amendedValue ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:amendmentReason ; sh:datatype xsd:string ] .
+
+workbench:AnnotationShape a sh:NodeShape ;
+    sh:targetClass workbench:Annotation ;
+    sh:property [ sh:path workbench:annotatesRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:annotationText ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:annotationProperty ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:annotationValue ; sh:datatype xsd:string ] ;
+    # Require at least one of annotationText / annotationValue.
+    sh:or (
+        [ sh:path workbench:annotationText ; sh:minCount 1 ]
+        [ sh:path workbench:annotationValue ; sh:minCount 1 ]
+    ) .
+
+workbench:RetractionShape a sh:NodeShape ;
+    sh:targetClass workbench:Retraction ;
+    sh:property [ sh:path workbench:retractsRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:retractionReason ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:supersededBy ; sh:nodeKind sh:IRI ] .
+
+workbench:TombstoneShape a sh:NodeShape ;
+    sh:targetClass workbench:Tombstone ;
+    sh:property [ sh:path workbench:erasedRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:erasedType ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:contentHash ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path workbench:erasureReason ; sh:datatype xsd:string ] .

--- a/ontologies/workbench/v1-draft/workbench.shapes.ttl
+++ b/ontologies/workbench/v1-draft/workbench.shapes.ttl
@@ -48,9 +48,18 @@ workbench:RetractionShape a sh:NodeShape ;
     sh:property [ sh:path workbench:retractionReason ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:supersededBy ; sh:nodeKind sh:IRI ] .
 
+# Content-free audit event (v1-draft.0.3): records the erasure EVENT only —
+# erased record id, action, optional category/reason — never a content hash.
 workbench:TombstoneShape a sh:NodeShape ;
     sh:targetClass workbench:Tombstone ;
     sh:property [ sh:path workbench:erasedRecord ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    sh:property [ sh:path workbench:erasureAction ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:erasedType ; sh:datatype xsd:string ] ;
-    sh:property [ sh:path workbench:contentHash ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path workbench:erasureReason ; sh:datatype xsd:string ] .
+
+# Verification axis (v1-draft.0.3): orthogonal to cascade:dataProvenance.
+# Uses sh:in (not sh:class) so the constraint is self-contained in the shapes
+# graph — validating a bucket record needs no ontology individual-typing.
+workbench:VerificationStatusShape a sh:NodeShape ;
+    sh:targetObjectsOf workbench:verificationStatus ;
+    sh:in ( workbench:Unverified workbench:Confirmed workbench:Refuted ) .

--- a/ontologies/workbench/v1-draft/workbench.ttl
+++ b/ontologies/workbench/v1-draft/workbench.ttl
@@ -21,9 +21,9 @@
     dct:description "Layer 3 vocabulary for the Cascade Workbench desktop investigation app."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-06-16"^^xsd:date ;
-    dct:modified "2026-06-16"^^xsd:date ;
+    dct:modified "2026-06-22"^^xsd:date ;
     owl:versionInfo "1.0-draft" ;
-    rdfs:comment "Holds the app-specific workspace objects only: Investigation, ImportedConversation, Hypothesis, Pin, InvestigationNote. The assertion/evidence/verdict grounding model is deliberately NOT here (it is cross-cutting Layer 2 evidence:). Phenotype capture is NOT here (it extends genomics:). Per the Layer 3 graduation rule, any class here that proves useful to other apps should graduate to Layer 2. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
+    rdfs:comment "Holds the app-specific workspace objects only: Investigation, ImportedConversation, Hypothesis, Pin, InvestigationNote, plus the append-only record-amendment overlays (Amendment, Annotation, Retraction, Tombstone). The assertion/evidence/verdict grounding model is deliberately NOT here (it is cross-cutting Layer 2 evidence:). Phenotype capture is NOT here (it extends genomics:). Per the Layer 3 graduation rule, any class here that proves useful to other apps should graduate to Layer 2. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/workbench/v1-draft/> .
 
 # ============================================================================
@@ -154,3 +154,98 @@ workbench:pinNote a owl:DatatypeProperty ; rdfs:label "pin note"@en ;
     rdfs:domain workbench:Pin ; rdfs:range xsd:string .
 workbench:noteText a owl:DatatypeProperty ; rdfs:label "note text"@en ;
     rdfs:domain workbench:InvestigationNote ; rdfs:range xsd:string .
+
+# ============================================================================
+# Append-only record amendment overlays
+# ----------------------------------------------------------------------------
+# Original records in a Pod are immutable. Every edit/delete is a NEW overlay
+# resource (Amendment / Annotation / Retraction / Tombstone) written to the
+# Pod's annotations/ directory and discovered at query time. The overlays carry
+# cascade:dataProvenance cascade:SelfReported, an optional prov:wasAttributedTo
+# actor, and a dct:created timestamp. Added in workbench v1-draft.0.2.
+# ============================================================================
+
+workbench:Amendment a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Amendment"@en ;
+    rdfs:comment "An append-only overlay that overrides one property value on an existing record without mutating the original. Names the amended record, the predicate CURIE being overridden, and the new value. Discovered at query time so the effective value can be projected over the immutable original."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2" .
+
+workbench:Annotation a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Annotation"@en ;
+    rdfs:comment "An append-only overlay that ADDS a note or an extra attribute to an existing record without overriding any of its values. Use Amendment to override; use Annotation to augment."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2" .
+
+workbench:Retraction a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Retraction"@en ;
+    rdfs:comment "An append-only soft-delete / supersede overlay (the entered-in-error pattern). The retracted record's bytes are retained; the Retraction marks it as withdrawn and may point at the kept record when merging duplicates."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2" .
+
+workbench:Tombstone a owl:Class ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:label "Tombstone"@en ;
+    rdfs:comment "A hard-erase audit marker. Unlike a Retraction, the erased record's bytes are gone from its bucket file; the Tombstone retains the fact of erasure plus the sha-256 content hash of the erased resource so the deletion is auditable and verifiable."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2" .
+
+# ── Properties shared by all overlay classes ────────────────────────────────
+# (cascade:dataProvenance, prov:wasAttributedTo, and dct:created are reused
+#  from core/PROV-O/Dublin Core; no new predicates are minted for those.)
+
+# ── Properties — Amendment ──────────────────────────────────────────────────
+
+workbench:amendsRecord a owl:ObjectProperty ; rdfs:label "amends record"@en ;
+    rdfs:comment "The existing record whose property value this Amendment overrides."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range rdfs:Resource .
+workbench:amendsProperty a owl:DatatypeProperty ; rdfs:label "amends property"@en ;
+    rdfs:comment "The predicate CURIE being overridden, e.g. \"clinical:dosage\"."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+workbench:amendedValue a owl:DatatypeProperty ; rdfs:label "amended value"@en ;
+    rdfs:comment "The new value that supersedes the original value of amendsProperty."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+workbench:amendmentReason a owl:DatatypeProperty ; rdfs:label "amendment reason"@en ;
+    rdfs:comment "Optional free-text rationale for the amendment."@en ;
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+
+# ── Properties — Annotation ─────────────────────────────────────────────────
+
+workbench:annotatesRecord a owl:ObjectProperty ; rdfs:label "annotates record"@en ;
+    rdfs:comment "The existing record this Annotation augments."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range rdfs:Resource .
+workbench:annotationText a owl:DatatypeProperty ; rdfs:label "annotation text"@en ;
+    rdfs:comment "Optional free-text note attached to the record."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+workbench:annotationProperty a owl:DatatypeProperty ; rdfs:label "annotation property"@en ;
+    rdfs:comment "Optional predicate CURIE of an extra attribute being added (paired with annotationValue)."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+workbench:annotationValue a owl:DatatypeProperty ; rdfs:label "annotation value"@en ;
+    rdfs:comment "Optional value of the extra attribute named by annotationProperty."@en ;
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+
+# ── Properties — Retraction ─────────────────────────────────────────────────
+
+workbench:retractsRecord a owl:ObjectProperty ; rdfs:label "retracts record"@en ;
+    rdfs:comment "The existing record this Retraction soft-deletes / supersedes."@en ;
+    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource .
+workbench:retractionReason a owl:DatatypeProperty ; rdfs:label "retraction reason"@en ;
+    rdfs:comment "Optional free-text rationale (e.g. \"entered in error\")."@en ;
+    rdfs:domain workbench:Retraction ; rdfs:range xsd:string .
+workbench:supersededBy a owl:ObjectProperty ; rdfs:label "superseded by"@en ;
+    rdfs:comment "Optional pointer to the kept record when merging duplicates."@en ;
+    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource .
+
+# ── Properties — Tombstone ──────────────────────────────────────────────────
+
+workbench:erasedRecord a owl:ObjectProperty ; rdfs:label "erased record"@en ;
+    rdfs:comment "The id of the record whose bytes were hard-erased from its bucket file."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range rdfs:Resource .
+workbench:erasedType a owl:DatatypeProperty ; rdfs:label "erased type"@en ;
+    rdfs:comment "Optional rdf:type CURIE of the erased record, retained for audit."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+workbench:contentHash a owl:DatatypeProperty ; rdfs:label "content hash"@en ;
+    rdfs:comment "sha-256 hex digest of the erased resource's serialized triples, so the deletion is verifiable."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+workbench:erasureReason a owl:DatatypeProperty ; rdfs:label "erasure reason"@en ;
+    rdfs:comment "Optional free-text rationale for the hard erasure."@en ;
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .

--- a/ontologies/workbench/v1-draft/workbench.ttl
+++ b/ontologies/workbench/v1-draft/workbench.ttl
@@ -1,6 +1,24 @@
 # Cascade Workbench Vocabulary (Layer 3, app-specific) — v1-draft
 # Authored in spec/. Per draft policy, NOT registered in spec/VOCAB_VERSIONS
 # until v1.0 graduation.
+#
+# Changelog
+#   v1-draft.0.3 (2026-06-23)
+#     - Tombstone: REMOVED workbench:contentHash. A SHA-256 of an erased
+#       record's triples is still pseudonymised personal data (EDPB Guidelines
+#       01/2025; WP29 WP216 Table 5): health content is low-entropy and
+#       enumerable, so the hash is brute-forceable and re-creates the very
+#       erasure obligation the hard-erase discharged. A content-free event
+#       marker is the correct residue.
+#     - Tombstone: ADDED workbench:erasureAction (the action verb), so the
+#       Tombstone is a self-describing, content-free audit event
+#       (opaque id + actor + timestamp + action), not a content fingerprint.
+#     - ADDED the verification axis (workbench:verificationStatus +
+#       VerificationStatusValue {Unverified, Confirmed, Refuted}), orthogonal
+#       to the source axis (cascade:dataProvenance). Patient self-entered data
+#       is self-SOURCED and defaults to UNVERIFIED; this mirrors FHIR
+#       AllergyIntolerance/Condition.verificationStatus and is a candidate to
+#       graduate to clinical:/Layer 2 if it proves broadly useful.
 
 @prefix workbench: <https://ns.cascadeprotocol.org/workbench/v1#> .
 @prefix evidence:  <https://ns.cascadeprotocol.org/evidence/v1#> .
@@ -21,8 +39,8 @@
     dct:description "Layer 3 vocabulary for the Cascade Workbench desktop investigation app."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-06-16"^^xsd:date ;
-    dct:modified "2026-06-22"^^xsd:date ;
-    owl:versionInfo "1.0-draft" ;
+    dct:modified "2026-06-23"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.3" ;
     rdfs:comment "Holds the app-specific workspace objects only: Investigation, ImportedConversation, Hypothesis, Pin, InvestigationNote, plus the append-only record-amendment overlays (Amendment, Annotation, Retraction, Tombstone). The assertion/evidence/verdict grounding model is deliberately NOT here (it is cross-cutting Layer 2 evidence:). Phenotype capture is NOT here (it extends genomics:). Per the Layer 3 graduation rule, any class here that proves useful to other apps should graduate to Layer 2. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/workbench/v1-draft/> .
 
@@ -81,6 +99,13 @@ workbench:Retired   a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdf
     rdfs:comment "No longer pursued; kept for the record (not deleted)."@en .
 workbench:Excluded  a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Excluded"@en ;
     rdfs:comment "Actively ruled out by evidence."@en .
+
+workbench:Unverified a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Unverified"@en ;
+    rdfs:comment "Not corroborated by a clinician or authoritative source. The default for patient self-entered data. Maps to FHIR verificationStatus 'unconfirmed'."@en .
+workbench:Confirmed  a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Confirmed"@en ;
+    rdfs:comment "Corroborated. Maps to FHIR verificationStatus 'confirmed'."@en .
+workbench:Refuted    a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Refuted"@en ;
+    rdfs:comment "Disproved on review. Maps to FHIR verificationStatus 'refuted'."@en .
 
 # ============================================================================
 # Properties — Investigation
@@ -186,8 +211,13 @@ workbench:Retraction a owl:Class ;
 workbench:Tombstone a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Tombstone"@en ;
-    rdfs:comment "A hard-erase audit marker. Unlike a Retraction, the erased record's bytes are gone from its bucket file; the Tombstone retains the fact of erasure plus the sha-256 content hash of the erased resource so the deletion is auditable and verifiable."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.2" .
+    rdfs:comment "A content-free hard-erase audit marker. Unlike a Retraction, the erased record's bytes are gone from its bucket file; the Tombstone records only the EVENT of erasure — the erased record's opaque id, the actor (prov:wasAttributedTo), the timestamp (dct:created), and the action (workbench:erasureAction) — so the deletion is provably logged WITHOUT retaining any content of the erased record. It deliberately holds no content hash: a hash of an erased record's triples is still pseudonymised personal data (low-entropy health content is brute-forceable), which would re-create the erasure obligation the hard-erase just discharged."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.2; contentHash removed, erasureAction added in v1-draft.0.3" .
+
+workbench:VerificationStatusValue a owl:Class ;
+    rdfs:label "Verification Status Value"@en ;
+    rdfs:comment "Closed enumeration of a record's clinical verification state — the VERIFICATION axis, orthogonal to the SOURCE axis (cascade:dataProvenance). Mirrors FHIR AllergyIntolerance/Condition.verificationStatus. Candidate to graduate to clinical:/Layer 2."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.3" .
 
 # ── Properties shared by all overlay classes ────────────────────────────────
 # (cascade:dataProvenance, prov:wasAttributedTo, and dct:created are reused
@@ -241,11 +271,18 @@ workbench:erasedRecord a owl:ObjectProperty ; rdfs:label "erased record"@en ;
     rdfs:comment "The id of the record whose bytes were hard-erased from its bucket file."@en ;
     rdfs:domain workbench:Tombstone ; rdfs:range rdfs:Resource .
 workbench:erasedType a owl:DatatypeProperty ; rdfs:label "erased type"@en ;
-    rdfs:comment "Optional rdf:type CURIE of the erased record, retained for audit."@en ;
+    rdfs:comment "Optional rdf:type CURIE of the erased record (a category, e.g. \"clinical:Medication\"), retained for audit. Category-level only — it names the kind of record erased, never its content."@en ;
     rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
-workbench:contentHash a owl:DatatypeProperty ; rdfs:label "content hash"@en ;
-    rdfs:comment "sha-256 hex digest of the erased resource's serialized triples, so the deletion is verifiable."@en ;
+workbench:erasureAction a owl:DatatypeProperty ; rdfs:label "erasure action"@en ;
+    rdfs:comment "The action this Tombstone records, e.g. \"hard-erase\". Makes the Tombstone a self-describing, content-free audit event."@en ;
     rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
 workbench:erasureReason a owl:DatatypeProperty ; rdfs:label "erasure reason"@en ;
-    rdfs:comment "Optional free-text rationale for the hard erasure."@en ;
+    rdfs:comment "Optional free-text rationale for the hard erasure (author-supplied; keep content-free to preserve the erasure)."@en ;
     rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+
+# ── Properties — Verification axis (orthogonal to cascade:dataProvenance) ─────
+
+workbench:verificationStatus a owl:ObjectProperty ; rdfs:label "verification status"@en ;
+    rdfs:comment "A record's clinical verification state (VERIFICATION axis), independent of who reported it (SOURCE axis, cascade:dataProvenance). Open domain so it can tag any record; patient self-entered records default to workbench:Unverified."@en ;
+    rdfs:range workbench:VerificationStatusValue ;
+    owl:versionInfo "Added in workbench v1-draft.0.3" .


### PR DESCRIPTION
Extends the **draft** `workbench:` vocab (v1-draft, not in VOCAB_VERSIONS, free to extend) with the overlay resources for append-only record editing in Cascade Workbench. Originals are never modified; edits/deletes are new provenanced resources.

New classes + SHACL Core shapes (namespace `https://ns.cascadeprotocol.org/workbench/v1#`):
- `workbench:Amendment` — overrides one property of a record (`amendsRecord`, `amendsProperty`, `amendedValue`, `amendmentReason?`).
- `workbench:Annotation` — adds a note / attribute (`annotatesRecord`, `annotationText?`, `annotationProperty?`, `annotationValue?`).
- `workbench:Retraction` — soft-delete / supersede, the entered-in-error pattern (`retractsRecord`, `retractionReason?`, `supersededBy?`).
- `workbench:Tombstone` — hard-erase audit marker, content gone / fact retained (`erasedRecord`, `erasedType?`, `contentHash`, `erasureReason?`).

All carry `cascade:dataProvenance cascade:SelfReported`, optional `prov:wasAttributedTo`, and `dct:created`. Consumed by cascade-cli's new `pod amend/annotate/add-record/retract/erase` verbs. Draft, so no VOCAB_VERSIONS bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)