### PR TITLE
workbench:userSourceLabel (v1-draft.0.4) + downstream-sync ledger

### DIFF
--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -1,0 +1,74 @@
+# Pending downstream sync ledger
+
+**Purpose.** A vocabulary change is *authored* in `spec/` continuously, but its
+propagation to the six downstream repos (the steps 2–7 of the Vocabulary Change
+Checklist in the workspace `CLAUDE.md`) is **expensive to do one change at a
+time**. This ledger lets us accumulate authored-but-not-yet-propagated changes
+and run the full 7-repo sync **in one batch** at a release boundary (e.g. weekly,
+or when a draft vocab is promoted out of `v1-draft`).
+
+## Why batching is safe here
+
+1. **Shapes are open-world (not `sh:closed`).** A converter/importer can EMIT a
+   new predicate and the Pod still passes `cascade validate` *before* the
+   predicate is formally in the embedded shapes. So the DATA can ship as soon as
+   `spec/` defines the term; the shape/docs/SDK propagation can lag.
+2. **The `v1-draft` namespace is the accumulation buffer.** Draft ontologies
+   (e.g. `workbench/v1-draft`) are not listed in `VOCAB_VERSIONS` and do not gate
+   downstream releases. Terms accrue in draft; the 7-repo cascade fires only when
+   a draft is promoted to a released `vN`.
+
+## The seam (what must sync NOW vs what batches)
+
+| Need | Sync immediately | Batches |
+|---|---|---|
+| Importer/app emits a new **draft** predicate | `spec/` (author the term) | docs site, conformance, CLI shapes, both SDKs, agent |
+| A **released** vocab (`core`/`clinical`/…) gains a property | `spec/` + `cascade-cli` shapes (so `cascade validate` knows it) | docs site, conformance, both SDKs, agent |
+
+Open-world validation means even the released-vocab case usually does not *block*
+on the CLI shape sync; do it promptly only so `validate` documents the new term.
+
+## How to run the batch
+
+1. `cd spec && sh scripts/check-downstream-versions.sh` — see drift across repos.
+2. For each ledger row below, run the per-repo steps (CLAUDE.md checklist 2–7).
+3. Tag `vocab/{name}-v{X.Y}`, update each repo's `VOCAB_VERSIONS`, clear the row.
+
+---
+
+## Open items
+
+### 1. `workbench:userSourceLabel` (draft) — authored, downstream pending
+
+- **Authored:** `spec/ontologies/workbench/v1-draft/workbench.ttl` (DatatypeProperty,
+  `owl:versionInfo 1.0-draft.0.4`, `dct:modified 2026-06-28`). DONE.
+- **What it is:** the user's chosen filing label for a record (the editable-source
+  "File under source" action), folded by the app as an annotation. Distinct from
+  the imported `clinical:sourceEHR`.
+- **Downstream:**
+  - [ ] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md`
+  - [ ] conformance — fixture exercising a re-filed record
+  - [ ] cascade-cli — embedded `workbench` shapes (currently emitted via generic
+        `pod annotate --property`; validates open-world, no shape change required to ship)
+  - [ ] sdk-typescript / sdk-python — predicate + context
+  - [ ] cascade-agent — query patterns
+  - **Batchable:** yes (draft; open-world).
+
+### 2. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
+
+- **Status:** DEFERRED from the 2026-06-28 source-attribution work. The Apple
+  Health authoritative-`sourceName` fix (importer reads `export.xml`
+  `<ClinicalRecord sourceName>`) made OID-based attribution **supplementary**, not
+  load-bearing, so this was not authored this round.
+- **What it would be:** carry the raw source-system OID (e.g.
+  `urn:oid:1.2.840.114350.1.13.296` = an Epic customer org) alongside the friendly
+  `clinical:sourceEHR`, as supplementary provenance + a stable cross-export key for
+  reconciliation and the OID→org registry. `clinical:` is a RELEASED vocab (1.9),
+  so authoring it bumps `clinical` to 1.10 and triggers the CLI shape sync.
+- **Trigger to author:** a non-Apple import (raw FHIR / C-CDA with no Apple
+  wrapper) needs OID-based attribution, OR the OID→org registry work begins.
+- **Downstream when authored:** full 7-repo checklist (released vocab).
+
+---
+
+_Last updated: 2026-06-28._

--- a/ontologies/workbench/CHANGELOG.md
+++ b/ontologies/workbench/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `workbench:` vocabulary. Draft status: not registered in `spec/VOCAB_VERSIONS` until v1.0 graduation (per the `genomics:` / `advisory:` draft policy).
 
+## v1-draft.0.4 (2026-06-28)
+
+- **Added the filing / organization axis:** `workbench:userSourceLabel` (xsd:string), the user-chosen label for the SOURCE a record is filed under in the Workbench "filing cabinet".
+- It is a filing **preference attributed to the user**, carried on a `workbench:Annotation` overlay (`annotationProperty` = `"workbench:userSourceLabel"`, `annotationValue` = the chosen label) whose overlay bears `cascade:SelfReported` provenance.
+- It **must not** overwrite the objective imported origin `clinical:sourceEHR`, which is preserved and displayed alongside. The effective source the UI groups by prefers this label when present, else falls back to `clinical:sourceEHR`, else the import-batch tag.
+- Orthogonal axis with an **open domain**, mirroring how `workbench:verificationStatus` was added in v1-draft.0.3, so it can file any record.
+- **SHACL:** no new shape required — the "file under source" action reuses the already-shaped string predicates `workbench:annotationProperty` / `workbench:annotationValue` on `workbench:Annotation`.
+
 ## v1-draft.0.1 (2026-06-16)
 
 - Initial draft authored in `spec/` for the Cascade Workbench desktop investigation app (Layer 3).

--- a/ontologies/workbench/v1-draft/workbench.ttl
+++ b/ontologies/workbench/v1-draft/workbench.ttl
@@ -3,6 +3,20 @@
 # until v1.0 graduation.
 #
 # Changelog
+#   v1-draft.0.4 (2026-06-28)
+#     - ADDED the filing/organization axis (workbench:userSourceLabel), the
+#       user-chosen label for the SOURCE a record is filed under in the
+#       Workbench "filing cabinet". It is a filing PREFERENCE attributed to the
+#       user: carried on a workbench:Annotation overlay (annotationProperty =
+#       "workbench:userSourceLabel", annotationValue = the label) bearing
+#       cascade:SelfReported provenance. It MUST NOT overwrite the objective
+#       imported origin clinical:sourceEHR, which is preserved and shown
+#       alongside; the effective grouping source prefers this label, else falls
+#       back to clinical:sourceEHR / the import-batch tag. Orthogonal axis with
+#       an open domain, mirroring how workbench:verificationStatus was added in
+#       v1-draft.0.3, so it can file any record. No new SHACL shape required:
+#       the Annotation overlay reuses the already-shaped string predicates
+#       workbench:annotationProperty and workbench:annotationValue.
 #   v1-draft.0.3 (2026-06-23)
 #     - Tombstone: REMOVED workbench:contentHash. A SHA-256 of an erased
 #       record's triples is still pseudonymised personal data (EDPB Guidelines
@@ -39,8 +53,8 @@
     dct:description "Layer 3 vocabulary for the Cascade Workbench desktop investigation app."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-06-16"^^xsd:date ;
-    dct:modified "2026-06-23"^^xsd:date ;
-    owl:versionInfo "1.0-draft.0.3" ;
+    dct:modified "2026-06-28"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.4" ;
     rdfs:comment "Holds the app-specific workspace objects only: Investigation, ImportedConversation, Hypothesis, Pin, InvestigationNote, plus the append-only record-amendment overlays (Amendment, Annotation, Retraction, Tombstone). The assertion/evidence/verdict grounding model is deliberately NOT here (it is cross-cutting Layer 2 evidence:). Phenotype capture is NOT here (it extends genomics:). Per the Layer 3 graduation rule, any class here that proves useful to other apps should graduate to Layer 2. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/workbench/v1-draft/> .
 
@@ -286,3 +300,10 @@ workbench:verificationStatus a owl:ObjectProperty ; rdfs:label "verification sta
     rdfs:comment "A record's clinical verification state (VERIFICATION axis), independent of who reported it (SOURCE axis, cascade:dataProvenance). Open domain so it can tag any record; patient self-entered records default to workbench:Unverified."@en ;
     rdfs:range workbench:VerificationStatusValue ;
     owl:versionInfo "Added in workbench v1-draft.0.3" .
+
+# ── Properties — Filing / organization axis (orthogonal to the imported origin) ─
+
+workbench:userSourceLabel a owl:DatatypeProperty ; rdfs:label "user source label"@en ;
+    rdfs:comment "The user-chosen FILING label for the SOURCE a record is organized under in the Workbench 'filing cabinet' (the ORGANIZATION axis). It is a filing PREFERENCE attributed to the user, carried on a workbench:Annotation (annotationProperty = \"workbench:userSourceLabel\", annotationValue = the chosen label) whose overlay bears cascade:SelfReported provenance. It MUST NOT alter the objective imported origin clinical:sourceEHR, which is preserved and displayed alongside. The effective source the UI groups records by prefers this label when present, else falls back to the imported origin (clinical:sourceEHR, else the import-batch tag). Open domain (like workbench:verificationStatus) so it can file any record."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in workbench v1-draft.0.4" .


### PR DESCRIPTION
Two small, batch-safe additions supporting the Workbench source-attribution work.

- **`workbench:userSourceLabel` (`aa93913`, v1-draft.0.4)** — a DatatypeProperty for the user's chosen filing label on a record (the editable-source "File under source" action), distinct from the imported `clinical:sourceEHR`. Authored in the `workbench` draft namespace (open-world), so the Workbench can emit it now and the pod still validates.
- **`PENDING_DOWNSTREAM_SYNC.md` (`2af8fc3`)** — a ledger that accumulates authored-but-not-yet-propagated vocabulary changes so the 7-repo downstream sync runs in one batch at a release boundary, instead of per-change. Documents the seam (open-world shapes + the v1-draft namespace) that makes batching safe, and tracks `workbench:userSourceLabel` (downstream pending) and the deferred `clinical:sourceSystemOID`.

Neither change requires the full 7-repo cascade to merge (draft vocab + a docs file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
