### PR TITLE
evidence: verdict taxonomy v2 facet model (v1-draft.0.2)

### DIFF
--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -54,7 +54,39 @@ on the CLI shape sync; do it promptly only so `validate` documents the new term.
   - [ ] cascade-agent — query patterns
   - **Batchable:** yes (draft; open-world).
 
-### 2. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
+### 2. `evidence:` verdict taxonomy v2 facet model (draft) — authored, downstream pending
+
+- **Authored:** `spec/ontologies/evidence/v1-draft/evidence.ttl` +
+  `evidence.shapes.ttl` (`owl:versionInfo 1.0-draft.0.2`, `dct:modified
+  2026-07-01`, tag `vocab/evidence-v1-draft.0.2`). DONE.
+- **What it is:** the grounding outcome moves from the flat 4-value
+  `evidence:verdict` to orthogonal facets on the Assertion
+  (`evidence:direction` / `basis` / `strength` / `settled` / `reason` object
+  properties over closed enumerations, `evidence:confidence` xsd:decimal).
+  The facets are the canonical serialized form; the SHACL grounding invariant
+  is generalized (SHACL Core): a grounded result of EITHER basis requires
+  >= 1 evidence link, plus facet-consistency constraints. `evidence:verdict`
+  and the `VerdictValue` individuals are deprecated, kept one release.
+- **Code sync (already done in lockstep, not batched):**
+  `cascade-workbench/packages/contracts` (invariant + migration) and
+  `packages/claims` `reify()`; Workbench grounding-gate fixtures exercise the
+  new shapes against the real validator.
+- **Downstream:**
+  - [ ] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md`
+  - [ ] conformance — facet fixtures (grounded-without-link INVALID,
+        NeedsEvidence-with-grounded-direction INVALID, either-basis VALID);
+        interim copies live in `cascade-workbench/fixtures/grounding/`
+  - [ ] cascade-cli — embedded `evidence` shapes via `sync-shapes-from-spec.sh`
+        (Workbench passes its own synced copy via `--shapes` meanwhile)
+  - [ ] sdk-typescript / sdk-python — facet predicates + context
+  - [ ] cascade-agent — query patterns
+  - **Batchable:** yes (draft; open-world).
+- **At v1.0 graduation (do NOT batch-forget):** remove `evidence:verdict` +
+  the `VerdictValue` individuals and the legacy SHACL branch; make
+  `evidence:settled` `sh:minCount 1`; drop the derived legacy `Verdict` from
+  `@cascade-workbench/contracts`.
+
+### 3. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
 
 - **Status:** DEFERRED from the 2026-06-28 source-attribution work. The Apple
   Health authoritative-`sourceName` fix (importer reads `export.xml`
@@ -71,4 +103,4 @@ on the CLI shape sync; do it promptly only so `validate` documents the new term.
 
 ---
 
-_Last updated: 2026-06-28._
+_Last updated: 2026-07-01._

--- a/ontologies/evidence/v1-draft/evidence.shapes.ttl
+++ b/ontologies/evidence/v1-draft/evidence.shapes.ttl
@@ -4,6 +4,22 @@
 # NOT SHACL-SPARQL. This is deliberate: `cascade validate` uses
 # rdf-validate-shacl, which does not support SHACL-SPARQL constraints. A
 # sh:sparql formulation would parse but silently never fire. Keep this Core.
+#
+# CHANGELOG
+# v1-draft.0.2 (2026-07-01) — Verdict taxonomy v2: AssertionShape moves to the
+#   facet model. The generalized grounding invariant: a grounded result
+#   (settled Settled, direction Supports/Contradicts/Mixed, basis not None) of
+#   EITHER basis requires >= 1 evidence link. Facet-consistency constraints:
+#   NeedsEvidence must not carry a grounded direction; a grounded direction
+#   must not carry basis None. The legacy evidence:verdict branch is retained
+#   (deprecated) so draft-period data still validates; every assertion must
+#   carry settled OR the legacy verdict. Removal of the legacy branch at v1.0.
+#
+# SHACL Core subtlety this file leans on: a property shape with sh:in
+# constrains only EXISTING values, so it is vacuously satisfied when the
+# property is absent. Each sh:or branch below reads as "the property is absent
+# or has only the listed values"; absence therefore never triggers the
+# grounded-direction constraints, which keeps legacy (facet-less) data valid.
 
 @prefix evidence: <https://ns.cascadeprotocol.org/evidence/v1#> .
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
@@ -19,18 +35,72 @@ evidence:AssertionShape a sh:NodeShape ;
     sh:targetClass evidence:Assertion ;
     sh:property [ sh:path evidence:assertionText ; sh:minCount 1 ; sh:datatype xsd:string ;
                   sh:message "Every Assertion must carry assertionText." ] ;
-    sh:property [ sh:path evidence:verdict ; sh:minCount 1 ; sh:maxCount 1 ;
+
+    # ── Facet enumerations (canonical form, v1-draft.0.2) ────────────────────
+    sh:property [ sh:path evidence:direction ; sh:maxCount 1 ;
+                  sh:in ( evidence:Supports evidence:Contradicts evidence:Mixed evidence:None ) ;
+                  sh:message "direction must be one of the DirectionValue individuals (Supports | Contradicts | Mixed | None)." ] ;
+    sh:property [ sh:path evidence:basis ; sh:maxCount 1 ;
+                  sh:in ( evidence:Record evidence:Literature evidence:RecordAndLiterature evidence:None ) ;
+                  sh:message "basis must be one of the BasisValue individuals (Record | Literature | RecordAndLiterature | None)." ] ;
+    sh:property [ sh:path evidence:strength ; sh:maxCount 1 ;
+                  sh:in ( evidence:Strong evidence:Moderate evidence:Weak ) ;
+                  sh:message "strength must be one of the StrengthValue individuals (Strong | Moderate | Weak)." ] ;
+    sh:property [ sh:path evidence:settled ; sh:maxCount 1 ;
+                  sh:in ( evidence:Settled evidence:NeedsEvidence ) ;
+                  sh:message "settled must be one of the SettledValue individuals (Settled | NeedsEvidence)." ] ;
+    sh:property [ sh:path evidence:reason ; sh:maxCount 1 ;
+                  sh:in ( evidence:NoRecord evidence:NeedsLiterature evidence:NotCheckableByNature ) ;
+                  sh:message "reason must be one of the NeedsEvidenceReasonValue individuals (NoRecord | NeedsLiterature | NotCheckableByNature)." ] ;
+    sh:property [ sh:path evidence:confidence ; sh:maxCount 1 ; sh:datatype xsd:decimal ;
+                  sh:minInclusive 0.0 ; sh:maxInclusive 1.0 ;
+                  sh:message "confidence must be an xsd:decimal in [0.0, 1.0]." ] ;
+
+    # ── Legacy verdict (deprecated; one-release transition) ──────────────────
+    sh:property [ sh:path evidence:verdict ; sh:maxCount 1 ;
                   sh:in ( evidence:Supported evidence:Contradicted evidence:Unverifiable evidence:NeedsLiterature ) ;
-                  sh:message "Every Assertion must carry exactly one verdict (one of the four VerdictValue individuals)." ] ;
-    # Grounding invariant (SHACL Core). Reads: the verdict is NOT a grounded
-    # one (i.e. it is Unverifiable or NeedsLiterature) OR there is at least one
-    # evidence link. Equivalent to: Supported/Contradicted => >= 1 evidence link.
+                  sh:message "verdict (deprecated) must be one of the four VerdictValue individuals when present." ] ;
+
+    # Every assertion is graded: it carries the facet form (settled) or, for
+    # draft-period data, the deprecated flat verdict.
+    sh:or (
+        [ sh:property [ sh:path evidence:settled ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path evidence:verdict ; sh:minCount 1 ] ]
+    ) ;
+
+    # ── Grounding invariant, generalized (SHACL Core) ────────────────────────
+    # A grounded result — settled Settled AND direction Supports/Contradicts/
+    # Mixed AND basis not None — of EITHER basis requires >= 1 evidence link.
+    # Reads: not settled, or direction None, or basis None, or >= 1 link.
+    sh:or (
+        [ sh:property [ sh:path evidence:settled ; sh:in ( evidence:NeedsEvidence ) ] ]
+        [ sh:property [ sh:path evidence:direction ; sh:in ( evidence:None ) ] ]
+        [ sh:property [ sh:path evidence:basis ; sh:in ( evidence:None ) ] ]
+        [ sh:property [ sh:path evidence:hasEvidenceLink ; sh:minCount 1 ] ]
+    ) ;
+
+    # ── Facet consistency: NeedsEvidence must not carry a grounded direction.
+    # Reads: settled is Settled (or absent), or direction is None (or absent).
+    sh:or (
+        [ sh:property [ sh:path evidence:settled ; sh:in ( evidence:Settled ) ] ]
+        [ sh:property [ sh:path evidence:direction ; sh:in ( evidence:None ) ] ]
+    ) ;
+
+    # ── Facet consistency: a grounded direction requires a real basis.
+    # Reads: direction is None (or absent), or basis is not None.
+    sh:or (
+        [ sh:property [ sh:path evidence:direction ; sh:in ( evidence:None ) ] ]
+        [ sh:property [ sh:path evidence:basis ; sh:not [ sh:in ( evidence:None ) ] ] ]
+    ) ;
+
+    # ── Legacy grounding invariant (deprecated branch; removal at v1.0):
+    # Supported/Contradicted => >= 1 evidence link.
     sh:or (
         [ sh:property [ sh:path evidence:verdict ;
                         sh:not [ sh:in ( evidence:Supported evidence:Contradicted ) ] ] ]
         [ sh:property [ sh:path evidence:hasEvidenceLink ; sh:minCount 1 ] ]
     ) ;
-    sh:message "Grounding invariant: an Assertion with verdict Supported or Contradicted must carry at least one evidence link (evidence:hasEvidenceLink)." .
+    sh:message "Grounding invariant: a grounded Assertion (settled Settled with direction Supports/Contradicts/Mixed and basis not None, or legacy verdict Supported/Contradicted) must carry at least one evidence link (evidence:hasEvidenceLink), and its facets must be mutually consistent." .
 
 evidence:EvidenceLinkShape a sh:NodeShape ;
     sh:targetClass evidence:EvidenceLink ;

--- a/ontologies/evidence/v1-draft/evidence.ttl
+++ b/ontologies/evidence/v1-draft/evidence.ttl
@@ -1,6 +1,28 @@
 # Cascade Evidence Vocabulary (Layer 2, cross-cutting) — v1-draft
 # Authored in spec/. Per draft policy (cf. genomics:, advisory:), NOT registered
 # in spec/VOCAB_VERSIONS until v1.0 graduation.
+#
+# CHANGELOG
+# v1-draft.0.2 (2026-07-01) — Verdict taxonomy v2: the facet model (Workbench
+#   grounding plan §4.1 / platform plan §4.6). The grounding outcome is now
+#   expressed as orthogonal facets on the Assertion — evidence:direction,
+#   evidence:basis, evidence:strength, evidence:settled, evidence:reason
+#   (object properties over new closed enumerations DirectionValue, BasisValue,
+#   StrengthValue, SettledValue, NeedsEvidenceReasonValue) plus
+#   evidence:confidence (xsd:decimal, [0,1]). The FACETS are the canonical
+#   serialized form. The flat evidence:verdict property and the VerdictValue
+#   individuals are DEPRECATED, not removed: draft-period data and fixtures
+#   already carry evidence:verdict, and the SHACL shapes keep a legacy branch
+#   so that data still validates during the one-release transition. Both are
+#   scheduled for removal at v1.0 graduation (see spec/PENDING_DOWNSTREAM_SYNC.md).
+#   Individual reuse: evidence:Supports and evidence:Contradicts are typed as
+#   both StanceValue (per-link) and DirectionValue (aggregate); evidence:None
+#   is both a DirectionValue and a BasisValue; evidence:NeedsLiterature is both
+#   a deprecated VerdictValue and a NeedsEvidenceReasonValue. Local names match
+#   the code mirror (@cascade-workbench/contracts grounding.ts) exactly.
+# v1-draft.0.1 (2026-06-16) — Initial draft: Assertion / EvidenceLink /
+#   Citation / GroundingActivity, flat VerdictValue + StanceValue enumerations,
+#   grounding invariant.
 
 @prefix evidence: <https://ns.cascadeprotocol.org/evidence/v1#> .
 @prefix cascade:  <https://ns.cascadeprotocol.org/core/v1#> .
@@ -20,8 +42,8 @@
     dct:description "Layer 2 cross-cutting vocabulary for grounding assertions in cited evidence with explicit verdicts."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-06-16"^^xsd:date ;
-    dct:modified "2026-06-16"^^xsd:date ;
-    owl:versionInfo "1.0-draft" ;
+    dct:modified "2026-07-01"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.2" ;
     rdfs:comment "Generalizes the assertion -> evidence -> verdict pattern needed by Cascade Workbench (checking claims pulled from AI conversations against a patient's records and literature), the Cascade Appeal system (citing clinical evidence against policy criteria, cf. coverage:deniedClinicalContext), and PGx/genomics decision support. Reuses core provenance primitives (cascade:extractionModel, cascade:extractionConfidence, cascade:requiresUserReview, prov:wasDerivedFrom) rather than redefining them. Uses 'Assertion' (not 'Claim') to avoid collision with coverage:ClaimRecord. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/evidence/v1-draft/> .
 
@@ -53,32 +75,98 @@ evidence:GroundingActivity a owl:Class ;
     owl:versionInfo "Added in evidence v1-draft.0.1" .
 
 evidence:VerdictValue a owl:Class ;
-    rdfs:label "Verdict Value"@en ;
-    rdfs:comment "Closed enumeration of an Assertion's grounding verdict. Instances are the named individuals below."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.1" .
+    owl:deprecated true ;
+    rdfs:label "Verdict Value (deprecated)"@en ;
+    rdfs:comment "DEPRECATED in v1-draft.0.2: the flat verdict enumeration is superseded by the facet model (evidence:direction / evidence:basis / evidence:strength / evidence:settled / evidence:reason). Retained one release so draft-period data carrying evidence:verdict still validates; clients derive the flat value from the facets in code and MUST NOT serialize it going forward. Scheduled for removal at v1.0 graduation."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.1; deprecated in v1-draft.0.2" .
 
 evidence:StanceValue a owl:Class ;
     rdfs:label "Stance Value"@en ;
     rdfs:comment "Closed enumeration of the direction of an EvidenceLink. Instances are the named individuals below."@en ;
     owl:versionInfo "Added in evidence v1-draft.0.1" .
 
+# ── Facet enumeration classes (verdict taxonomy v2, grounding plan §4.1) ─────
+
+evidence:DirectionValue a owl:Class ;
+    rdfs:label "Direction Value"@en ;
+    rdfs:comment "Closed enumeration of what the evidence, in aggregate, says about the Assertion: Supports | Contradicts | Mixed | None. The per-link analogue is StanceValue; evidence:Supports and evidence:Contradicts are shared individuals of both."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:BasisValue a owl:Class ;
+    rdfs:label "Basis Value"@en ;
+    rdfs:comment "Closed enumeration of where the evidence is: Record | Literature | RecordAndLiterature | None. New bases (guideline, clinician annotation) slot in here without breaking any flat enum."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:StrengthValue a owl:Class ;
+    rdfs:label "Strength Value"@en ;
+    rdfs:comment "Closed enumeration of the quantity/quality of the evidence: Strong | Moderate | Weak. On basis Record, strength is a pure deterministic function of the match (guardrail G-2), never model-emitted."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:SettledValue a owl:Class ;
+    rdfs:label "Settled Value"@en ;
+    rdfs:comment "Closed enumeration of whether the Assertion is resolved: Settled | NeedsEvidence."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:NeedsEvidenceReasonValue a owl:Class ;
+    rdfs:label "Needs-Evidence Reason Value"@en ;
+    rdfs:comment "Closed enumeration of why an Assertion still needs evidence, when it does: NoRecord | NeedsLiterature | NotCheckableByNature."@en ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
 # ============================================================================
 # Named Individuals (enumerations)
 # ============================================================================
 
-evidence:Supported       a owl:NamedIndividual, evidence:VerdictValue ; rdfs:label "Supported"@en ;
-    rdfs:comment "The patient's records and/or literature substantiate the assertion."@en .
-evidence:Contradicted    a owl:NamedIndividual, evidence:VerdictValue ; rdfs:label "Contradicted"@en ;
-    rdfs:comment "The patient's records and/or literature directly conflict with the assertion."@en .
-evidence:Unverifiable    a owl:NamedIndividual, evidence:VerdictValue ; rdfs:label "Unverifiable"@en ;
-    rdfs:comment "No evidence available in the current Pod to support or refute. NOT a judgment that the assertion is false."@en .
-evidence:NeedsLiterature a owl:NamedIndividual, evidence:VerdictValue ; rdfs:label "Needs Literature"@en ;
-    rdfs:comment "Cannot be settled from the patient's records alone; requires external literature retrieval to grade."@en .
+# Deprecated flat verdicts (v1-draft.0.2): retained one release for draft-period
+# data; derive from the facets in code, do not serialize. Removal at v1.0.
+evidence:Supported       a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Supported (deprecated)"@en ;
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Supports. The patient's records and/or literature substantiate the assertion."@en .
+evidence:Contradicted    a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Contradicted (deprecated)"@en ;
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Contradicts. The patient's records and/or literature directly conflict with the assertion."@en .
+evidence:Unverifiable    a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Unverifiable (deprecated)"@en ;
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NoRecord. No evidence available in the current Pod to support or refute. NOT a judgment that the assertion is false."@en .
 
-evidence:Supports    a owl:NamedIndividual, evidence:StanceValue ; rdfs:label "Supports"@en .
-evidence:Contradicts a owl:NamedIndividual, evidence:StanceValue ; rdfs:label "Contradicts"@en .
+evidence:Supports    a owl:NamedIndividual, evidence:StanceValue, evidence:DirectionValue ; rdfs:label "Supports"@en ;
+    rdfs:comment "As a StanceValue: this one link supports. As a DirectionValue (v1-draft.0.2): the evidence in aggregate supports."@en .
+evidence:Contradicts a owl:NamedIndividual, evidence:StanceValue, evidence:DirectionValue ; rdfs:label "Contradicts"@en ;
+    rdfs:comment "As a StanceValue: this one link contradicts. As a DirectionValue (v1-draft.0.2): the evidence in aggregate contradicts."@en .
 evidence:Contextual  a owl:NamedIndividual, evidence:StanceValue ; rdfs:label "Contextual"@en ;
     rdfs:comment "Relevant background that neither supports nor refutes."@en .
+
+# ── Facet individuals (v1-draft.0.2) ─────────────────────────────────────────
+
+evidence:Mixed a owl:NamedIndividual, evidence:DirectionValue ; rdfs:label "Mixed"@en ;
+    rdfs:comment "The evidence points in both directions; see the individual links."@en .
+evidence:None a owl:NamedIndividual, evidence:DirectionValue, evidence:BasisValue ; rdfs:label "None"@en ;
+    rdfs:comment "As a DirectionValue: the evidence says nothing. As a BasisValue: there is no evidence base. Shared individual; the property it appears on disambiguates."@en .
+
+evidence:Record a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Record"@en ;
+    rdfs:comment "The evidence is the patient's own Pod records (deterministic path, G-2)."@en .
+evidence:Literature a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Literature"@en ;
+    rdfs:comment "The evidence is published research; it has not been checked against the patient's records."@en .
+evidence:RecordAndLiterature a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Record and Literature"@en ;
+    rdfs:comment "Both the patient's records and published research contribute evidence."@en .
+
+evidence:Strong   a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Strong"@en ;
+    rdfs:comment "On the record path: exact code + value/negation match."@en .
+evidence:Moderate a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Moderate"@en ;
+    rdfs:comment "On the record path: code match with value absent or approximate."@en .
+evidence:Weak     a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Weak"@en ;
+    rdfs:comment "On the record path: lexical / recall-fallback match only."@en .
+
+evidence:Settled       a owl:NamedIndividual, evidence:SettledValue ; rdfs:label "Settled"@en ;
+    rdfs:comment "The claim is resolved by the cited evidence."@en .
+evidence:NeedsEvidence a owl:NamedIndividual, evidence:SettledValue ; rdfs:label "Needs Evidence"@en ;
+    rdfs:comment "The claim is not resolved; evidence:reason says why. A NeedsEvidence assertion carries direction None (a grounded direction here is facet-inconsistent and fails validation)."@en .
+
+evidence:NoRecord a owl:NamedIndividual, evidence:NeedsEvidenceReasonValue ; rdfs:label "No Record"@en ;
+    rdfs:comment "Nothing in the patient's records speaks to this. That does not make it wrong."@en .
+evidence:NotCheckableByNature a owl:NamedIndividual, evidence:NeedsEvidenceReasonValue ; rdfs:label "Not Checkable By Nature"@en ;
+    rdfs:comment "Subjective, personal, or otherwise unverifiable by its nature (instruction, opinion, tautology, meta)."@en .
+# evidence:NeedsLiterature doubles as a NeedsEvidenceReasonValue (below) and the
+# deprecated VerdictValue of the same local name; the code mirror uses the same
+# string for both, so one shared individual is exact.
+evidence:NeedsLiterature a owl:NamedIndividual, evidence:VerdictValue, evidence:NeedsEvidenceReasonValue ; rdfs:label "Needs Literature"@en ;
+    rdfs:comment "As a NeedsEvidenceReasonValue (v1-draft.0.2): the patient's records cannot settle this; it needs published evidence. As a VerdictValue it is DEPRECATED (use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NeedsLiterature)."@en .
 
 # ============================================================================
 # Properties — Assertion
@@ -90,8 +178,52 @@ evidence:assertionText a owl:DatatypeProperty ;
     rdfs:domain evidence:Assertion ; rdfs:range xsd:string .
 
 evidence:verdict a owl:ObjectProperty ;
-    rdfs:label "verdict"@en ;
+    owl:deprecated true ;
+    rdfs:label "verdict (deprecated)"@en ;
+    rdfs:comment "DEPRECATED in v1-draft.0.2: superseded by the facet properties (direction / basis / strength / settled / reason / confidence), which are the canonical serialized form. Retained one release so draft-period data validates; derive the flat value from the facets in code, do not serialize it. Removal at v1.0 graduation."@en ;
     rdfs:domain evidence:Assertion ; rdfs:range evidence:VerdictValue .
+
+# ── Facet properties (verdict taxonomy v2, v1-draft.0.2) ─────────────────────
+# The canonical grounding outcome. Grounding invariant (SHACL Core, see
+# evidence.shapes.ttl): a grounded result — settled Settled, direction one of
+# Supports/Contradicts/Mixed, basis not None — of EITHER basis requires at
+# least one evidence:hasEvidenceLink.
+
+evidence:direction a owl:ObjectProperty ;
+    rdfs:label "direction"@en ;
+    rdfs:comment "What the evidence, in aggregate, says about the assertion."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:DirectionValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:basis a owl:ObjectProperty ;
+    rdfs:label "basis"@en ;
+    rdfs:comment "Where the evidence is. Tells the UI which regime produced the result: Record is the deterministic path (G-2), Literature is model+search."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:BasisValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:strength a owl:ObjectProperty ;
+    rdfs:label "strength"@en ;
+    rdfs:comment "Quantity/quality of the evidence. On basis Record this is a pure deterministic function of the match (G-2), never model-emitted."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:StrengthValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:settled a owl:ObjectProperty ;
+    rdfs:label "settled"@en ;
+    rdfs:comment "Whether the assertion is resolved by the cited evidence."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:SettledValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:reason a owl:ObjectProperty ;
+    rdfs:label "reason"@en ;
+    rdfs:comment "Why the assertion still needs evidence, when settled is NeedsEvidence."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:NeedsEvidenceReasonValue ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
+
+evidence:confidence a owl:DatatypeProperty ;
+    rdfs:label "confidence"@en ;
+    rdfs:comment "Confidence in the grounding result, [0.0, 1.0]. On basis Record this is a fixed function of match quality, never a model probability (G-2); on the literature path it may reflect model certainty. Distinct from evidence:groundingConfidence, which is the GroundingActivity's raw model confidence."@en ;
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:decimal ;
+    owl:versionInfo "Added in evidence v1-draft.0.2" .
 
 evidence:rationale a owl:DatatypeProperty ;
     rdfs:label "rationale"@en ;


### PR DESCRIPTION
## What

Phase 1B of the Workbench grounding agent plan (grounding plan §7, platform plan §4.6): the grounding outcome moves from the flat 4-value `evidence:verdict` to orthogonal facets as the canonical serialized form.

- **Facet model:** `evidence:direction` / `basis` / `strength` / `settled` / `reason` as object properties over new closed enumerations (`DirectionValue`, `BasisValue`, `StrengthValue`, `SettledValue`, `NeedsEvidenceReasonValue`), plus `evidence:confidence` (xsd:decimal, [0,1]). Local names match the frozen `@cascade-workbench/contracts` `GroundingResult` strings exactly.
- **Shared individuals (documented in the changelog):** `Supports`/`Contradicts` are typed as both Stance and Direction; `None` is both Direction and Basis; `NeedsLiterature` is both the deprecated Verdict and a Reason.
- **Deprecation, not removal:** `evidence:verdict` and the `VerdictValue` individuals are marked `owl:deprecated true` and kept one release, because draft-period data and fixtures still carry them and the SHACL keeps a legacy branch. Removal is scheduled at v1.0 graduation.
- **SHACL (Core only, no sh:sparql):** the grounding invariant generalizes to "a grounded result (settled Settled, direction Supports/Contradicts/Mixed, basis not None) of EITHER basis requires >= 1 evidence link", plus two facet-consistency constraints: NeedsEvidence must not carry a grounded direction, and a grounded direction requires a real basis.
- **Ledger:** downstream propagation recorded in `PENDING_DOWNSTREAM_SYNC.md` per draft policy (no `VOCAB_VERSIONS` row, no 7-repo fan-out), including the graduation checklist.

## Verification

- Every constraint verified against the real `cascade` (rdf-validate-shacl) engine via the Workbench grounding gate: 10 fixtures, each INVALID fixture isolating one constraint, all discriminating correctly (jedr-cal/cascade-workbench PR for Phase 1B).
- `evidence.ttl` parses clean through the same engine (261 quads).
- Tagged `vocab/evidence-v1-draft.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvyG2iC4RGimV8Emc8roCw