### PR TITLE
docs(schema): workbench: notes/flags/follow-ups as W3C Web Annotations (v1-draft.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: each entry is one milestone, dated, with a short prose summary and point
 
 ---
 
+## 2026-07-15 — workbench v1-draft.0.5 (notes / flags / follow-ups as W3C Web Annotations)
+
+Caregiver notes, "needs research" flags, and follow-ups become ONE substrate: `oa:Annotation` over one or more graph nodes, distinguished by `oa:motivatedBy`, with required PROV-O attribution. Maximal Layer-1 reuse: span selectors from `oa:`, due date + status for follow-ups from W3C RDF Calendar (`ical:due` / `ical:status`, follow-ups dual-typed `cal:Vtodo`). Exactly one term minted: `workbench:followUp` (an `oa:Motivation`, `skos:broader oa:questioning`). `workbench:InvestigationNote` removed (draft; unshipped), superseded by the substrate. New Pod container `notes/` documented in `pod-structure.md` §5.2. SHACL Core shapes verified against `cascade validate` with positive + negative fixtures. Unblocks Workbench shell Phase 9 (notes grammar).
+
+Tag: `vocab/workbench-v1-draft.0.5` (applied after merge). See `ontologies/workbench/CHANGELOG.md`. Downstream propagation is BATCHED per `PENDING_DOWNSTREAM_SYNC.md` (row 4) together with the outstanding v1-draft rows.
+
+---
+
 ## 2026-05-06 — genomics v1-draft.0.3 (shape relaxations from test-fixture review)
 
 Two SHACL shape relaxations on `genomics/v1-draft`. No vocabulary additions; shapes only.

--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -86,7 +86,36 @@ on the CLI shape sync; do it promptly only so `validate` documents the new term.
   `evidence:settled` `sh:minCount 1`; drop the derived legacy `Verdict` from
   `@cascade-workbench/contracts`.
 
-### 3. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
+### 3. `workbench:` notes / flags / follow-ups as Web Annotations (draft) — authored, downstream pending
+
+- **Authored:** `spec/ontologies/workbench/v1-draft/workbench.ttl` +
+  `workbench.shapes.ttl` (`owl:versionInfo 1.0-draft.0.5`, `dct:modified
+  2026-07-15`, tag `vocab/workbench-v1-draft.0.5` after merge) +
+  `pod-structure.md` §5.2 `notes/` container. DONE.
+- **What it is:** [NOTES-ANNOTATION-VOCAB] — caregiver notes, research flags,
+  and follow-ups as ONE `oa:Annotation` substrate distinguished by
+  `oa:motivatedBy`; required PROV-O attribution; follow-ups dual-typed
+  `cal:Vtodo` with `ical:due` / `ical:status`. One minted term
+  (`workbench:followUp`). `InvestigationNote` removed (unshipped). Unblocks
+  Workbench shell Phase 9.
+- **Code sync (lockstep, not batched):** Workbench Phase 9 emits/reads these
+  under `notes/`; the contracts package drops the stale `InvestigationNote`
+  types in the same PR.
+- **Downstream:**
+  - [ ] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md`
+  - [ ] conformance — fixtures: valid commenting/questioning/followUp notes
+        (multi-target + selector-anchored + Vtodo); INVALID
+        followUp-without-status, commenting-without-body, floating annotation
+        (recreate from the shapes-verification set in the authoring PR)
+  - [ ] cascade-cli — embedded `workbench` shapes via `sync-shapes-from-spec.sh`
+        (open-world: Phase 9 can ship before this lands; sync promptly so
+        `cascade validate` enforces the note shapes by default)
+  - [ ] sdk-typescript / sdk-python — `oa:`/`ical:` predicates + namespaces
+  - [ ] cascade-agent — query patterns (`notes/` container, motivation filters)
+  - **Batchable:** yes (draft; open-world). No JSON-LD context yet (drafts get
+    contexts at v1.0 graduation, same as the other draft rows).
+
+### 4. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
 
 - **Status:** DEFERRED from the 2026-06-28 source-attribution work. The Apple
   Health authoritative-`sourceName` fix (importer reads `export.xml`
@@ -103,4 +132,4 @@ on the CLI shape sync; do it promptly only so `validate` documents the new term.
 
 ---
 
-_Last updated: 2026-07-01._
+_Last updated: 2026-07-15._

--- a/ontologies/workbench/CHANGELOG.md
+++ b/ontologies/workbench/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `workbench:` vocabulary. Draft status: not registered in `spec/VOCAB_VERSIONS` until v1.0 graduation (per the `genomics:` / `advisory:` draft policy).
 
+## v1-draft.0.5 (2026-07-15)
+
+- **Added the notes / research-flags / follow-ups substrate as W3C Web Annotations** ([NOTES-ANNOTATION-VOCAB]; proposal `cascade-workbench/docs/planning/vocab-proposals/2026-07-13-notes-as-web-annotations.md`). All three artifacts are ONE thing, an `oa:Annotation` over one or more graph nodes, distinguished by `oa:motivatedBy`: caregiver note = `oa:commenting`, research flag = `oa:questioning`, follow-up = `workbench:followUp`.
+- **Layer-1 reuse, nothing redeclared:** `oa:` carries body (`oa:TextualBody`), multi-target (`oa:hasTarget`), motivation, and span selectors (`oa:TextQuoteSelector` / `oa:TextPositionSelector` via `oa:SpecificResource`); PROV-O carries required attribution (`prov:wasAttributedTo`, `prov:generatedAtTime`). Follow-ups are dual-typed `cal:Vtodo` and reuse W3C RDF Calendar `ical:due` (optional) + `ical:status` (required, RFC 5545 VTODO enum). `schema:dueDate` was considered and rejected: it does not exist (verified 404; schema.org defines only `paymentDueDate`).
+- **Minted exactly one term:** `workbench:followUp`, an `oa:Motivation` with `skos:broader oa:questioning`, per the Web Annotation model's custom-motivation extension rule.
+- **Removed** `workbench:InvestigationNote`, `workbench:hasNote`, `workbench:noteText` (draft removal; never emitted by shipping code). An investigation-scoped note is an `oa:Annotation` targeting the `workbench:Investigation`.
+- **SHACL (Core only, validator-enforced):** `WebAnnotationShape` (>= 1 target, >= 1 motivation, required attribution + `xsd:dateTime` timestamp), `CommentingBodyShape` (commenting requires a body), `FollowUpShape` (followUp requires `ical:status` in the VTODO enum). Verified against `cascade validate` with positive + negative fixtures (all three violation classes fire; valid multi-target, selector-anchored, and Vtodo notes pass).
+- **Pod placement:** notes live in a top-level `notes/` container (`pod-structure.md` §5.2), separate from `annotations/` (record-amendment overlays are edit machinery, not user content).
+
 ## v1-draft.0.4 (2026-06-28)
 
 - **Added the filing / organization axis:** `workbench:userSourceLabel` (xsd:string), the user-chosen label for the SOURCE a record is filed under in the Workbench "filing cabinet".

--- a/ontologies/workbench/v1-draft/workbench.shapes.ttl
+++ b/ontologies/workbench/v1-draft/workbench.shapes.ttl
@@ -5,6 +5,9 @@
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix oa:   <http://www.w3.org/ns/oa#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix ical: <http://www.w3.org/2002/12/cal/ical#> .
 
 <https://ns.cascadeprotocol.org/workbench/v1/shapes> a owl:Ontology ;
     owl:imports <https://ns.cascadeprotocol.org/workbench/v1#> ;
@@ -63,3 +66,40 @@ workbench:TombstoneShape a sh:NodeShape ;
 workbench:VerificationStatusShape a sh:NodeShape ;
     sh:targetObjectsOf workbench:verificationStatus ;
     sh:in ( workbench:Unverified workbench:Confirmed workbench:Refuted ) .
+
+# ── Notes / flags / follow-ups — the Web Annotation substrate (v1-draft.0.5) ─
+# Targets every oa:Annotation in the Pod (they live under notes/). SHACL Core
+# only, like the evidence grounding invariant, so `cascade validate` actually
+# enforces it. The conditional constraints use the sh:or( sh:not(...) ... )
+# pattern: "NOT motivated-by-X, OR carries the fields X requires".
+
+workbench:WebAnnotationShape a sh:NodeShape ;
+    sh:targetClass oa:Annotation ;
+    # At least one target: a note floats on nothing.
+    sh:property [ sh:path oa:hasTarget ; sh:minCount 1 ;
+                  sh:nodeKind sh:BlankNodeOrIRI ] ;
+    # Exactly which kind of note this is.
+    sh:property [ sh:path oa:motivatedBy ; sh:minCount 1 ; sh:nodeKind sh:IRI ] ;
+    # Attribution is load-bearing (caregiver vs patient vs agent): required.
+    sh:property [ sh:path prov:wasAttributedTo ; sh:minCount 1 ] ;
+    sh:property [ sh:path prov:generatedAtTime ; sh:minCount 1 ; sh:maxCount 1 ;
+                  sh:datatype xsd:dateTime ] .
+
+# A commenting note must actually say something: motivatedBy oa:commenting
+# requires a body.
+workbench:CommentingBodyShape a sh:NodeShape ;
+    sh:targetClass oa:Annotation ;
+    sh:or (
+        [ sh:not [ sh:property [ sh:path oa:motivatedBy ; sh:hasValue oa:commenting ] ] ]
+        [ sh:property [ sh:path oa:hasBody ; sh:minCount 1 ] ]
+    ) .
+
+# A follow-up is a to-do: motivatedBy workbench:followUp requires the RFC 5545
+# VTODO status (reused ical:status, closed enum); ical:due stays optional.
+workbench:FollowUpShape a sh:NodeShape ;
+    sh:targetClass oa:Annotation ;
+    sh:or (
+        [ sh:not [ sh:property [ sh:path oa:motivatedBy ; sh:hasValue workbench:followUp ] ] ]
+        [ sh:property [ sh:path ical:status ; sh:minCount 1 ; sh:maxCount 1 ;
+                        sh:in ( "NEEDS-ACTION" "IN-PROCESS" "COMPLETED" "CANCELLED" ) ] ]
+    ) .

--- a/ontologies/workbench/v1-draft/workbench.ttl
+++ b/ontologies/workbench/v1-draft/workbench.ttl
@@ -3,6 +3,34 @@
 # until v1.0 graduation.
 #
 # Changelog
+#   v1-draft.0.5 (2026-07-15)
+#     - ADDED the notes / flags / follow-ups substrate as W3C WEB ANNOTATIONS
+#       ([NOTES-ANNOTATION-VOCAB]; proposal 2026-07-13-notes-as-web-annotations
+#       in the Workbench vocab-proposals). Caregiver notes, "needs research"
+#       flags, and follow-ups are ONE artifact — an oa:Annotation over one or
+#       more graph nodes — distinguished by oa:motivatedBy (oa:commenting /
+#       oa:questioning / workbench:followUp). Layer-1 reuse, nothing
+#       redeclared: oa: carries body, multi-target, motivation, and span
+#       selectors (oa:TextQuoteSelector / oa:TextPositionSelector, the same
+#       byte-verified-span idea the Claims Ledger uses); PROV-O carries
+#       attribution (prov:wasAttributedTo — the caregiver, distinct from the
+#       patient and from any agent) and prov:generatedAtTime. Follow-ups are
+#       dual-typed cal:Vtodo and reuse W3C RDF Calendar ical:due +
+#       ical:status (RFC 5545 VTODO statuses) — schema:dueDate was considered
+#       and REJECTED because it does not exist (verified 404 at
+#       schema.org/dueDate; schema.org has only paymentDueDate).
+#     - MINTED exactly one term: workbench:followUp, an oa:Motivation with
+#       skos:broader oa:questioning, per the OA model's extension rule for
+#       custom motivations.
+#     - REMOVED workbench:InvestigationNote, workbench:hasNote, and
+#       workbench:noteText (draft removal; never emitted by shipping code —
+#       only type declarations existed in the Workbench contracts package).
+#       Superseded by the oa: substrate: an investigation-scoped note is an
+#       oa:Annotation whose oa:hasTarget is the workbench:Investigation. The
+#       contracts-type cleanup rides with shell Phase 9.
+#     - Pod placement: annotations live in a top-level notes/ container (see
+#       pod-structure.md §5.2), separate from annotations/ (which holds the
+#       record-amendment OVERLAYS below — machinery, not user content).
 #   v1-draft.0.4 (2026-06-28)
 #     - ADDED the filing/organization axis (workbench:userSourceLabel), the
 #       user-chosen label for the SOURCE a record is filed under in the
@@ -43,6 +71,9 @@
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix dct:  <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix oa:   <http://www.w3.org/ns/oa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ical: <http://www.w3.org/2002/12/cal/ical#> .
 
 # ============================================================================
 # Ontology Metadata
@@ -53,8 +84,8 @@
     dct:description "Layer 3 vocabulary for the Cascade Workbench desktop investigation app."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-06-16"^^xsd:date ;
-    dct:modified "2026-06-28"^^xsd:date ;
-    owl:versionInfo "1.0-draft.0.4" ;
+    dct:modified "2026-07-15"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.5" ;
     rdfs:comment "Holds the app-specific workspace objects only: Investigation, ImportedConversation, Hypothesis, Pin, InvestigationNote, plus the append-only record-amendment overlays (Amendment, Annotation, Retraction, Tombstone). The assertion/evidence/verdict grounding model is deliberately NOT here (it is cross-cutting Layer 2 evidence:). Phenotype capture is NOT here (it extends genomics:). Per the Layer 3 graduation rule, any class here that proves useful to other apps should graduate to Layer 2. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/workbench/v1-draft/> .
 
@@ -81,11 +112,6 @@ workbench:Hypothesis a owl:Class ;
 workbench:Pin a owl:Class ;
     rdfs:label "Pin"@en ;
     rdfs:comment "A curated bookmark within an Investigation pointing at any resource (a record, an assertion, a citation) with an optional note. The mechanism by which the user assembles evidence NotebookLM-style."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.1" .
-
-workbench:InvestigationNote a owl:Class ;
-    rdfs:label "Investigation Note"@en ;
-    rdfs:comment "A free-text note authored by the user within an Investigation."@en ;
     owl:versionInfo "Added in workbench v1-draft.0.1" .
 
 workbench:InvestigationStatusValue a owl:Class ;
@@ -148,8 +174,9 @@ workbench:hasHypothesis a owl:ObjectProperty ; rdfs:label "has hypothesis"@en ;
     rdfs:domain workbench:Investigation ; rdfs:range workbench:Hypothesis .
 workbench:hasPin a owl:ObjectProperty ; rdfs:label "has pin"@en ;
     rdfs:domain workbench:Investigation ; rdfs:range workbench:Pin .
-workbench:hasNote a owl:ObjectProperty ; rdfs:label "has note"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range workbench:InvestigationNote .
+# (workbench:hasNote / workbench:InvestigationNote removed in v1-draft.0.5:
+#  an investigation-scoped note is an oa:Annotation targeting the
+#  Investigation — see the Web Annotation substrate section below.)
 
 # ============================================================================
 # Properties — ImportedConversation
@@ -183,7 +210,7 @@ workbench:refutedByAssertion a owl:ObjectProperty ; rdfs:label "refuted by asser
     rdfs:domain workbench:Hypothesis ; rdfs:range evidence:Assertion .
 
 # ============================================================================
-# Properties — Pin / Note
+# Properties — Pin
 # ============================================================================
 
 workbench:pinnedResource a owl:ObjectProperty ; rdfs:label "pinned resource"@en ;
@@ -191,8 +218,50 @@ workbench:pinnedResource a owl:ObjectProperty ; rdfs:label "pinned resource"@en 
     rdfs:domain workbench:Pin ; rdfs:range rdfs:Resource .
 workbench:pinNote a owl:DatatypeProperty ; rdfs:label "pin note"@en ;
     rdfs:domain workbench:Pin ; rdfs:range xsd:string .
-workbench:noteText a owl:DatatypeProperty ; rdfs:label "note text"@en ;
-    rdfs:domain workbench:InvestigationNote ; rdfs:range xsd:string .
+
+# ============================================================================
+# Notes, research flags, and follow-ups — the W3C Web Annotation substrate
+# ----------------------------------------------------------------------------
+# Added in workbench v1-draft.0.5 ([NOTES-ANNOTATION-VOCAB]). Caregiver notes
+# ("more tired than usual"), "needs research" flags on claims, and follow-ups
+# ("recheck TSH in 3 months") are ONE artifact: an oa:Annotation over one or
+# more graph nodes, distinguished by oa:motivatedBy. This section deliberately
+# REDECLARES NOTHING from oa:/ical:/prov: — it documents the usage profile and
+# mints the single term the standards lack.
+#
+# The profile (enforced by workbench.shapes.ttl):
+#   - a workbench note IS an oa:Annotation with >= 1 oa:hasTarget (targets may
+#     be any Pod resource: records, conditions, evidence:Assertion instances,
+#     a workbench:Investigation, or an oa:SpecificResource carrying an
+#     oa:TextQuoteSelector / oa:TextPositionSelector to pin a passage inside a
+#     document or transcript — the same byte-verified-span idea the Claims
+#     Ledger uses);
+#   - body text is an oa:TextualBody (rdf:value carries the text);
+#   - motivation mapping: caregiver note = oa:commenting; research flag =
+#     oa:questioning (target is typically an assertion/claim node);
+#     follow-up / open loop = workbench:followUp (below);
+#   - attribution is REQUIRED: prov:wasAttributedTo (who wrote it — the
+#     caregiver, distinct from the patient and from any agent) and
+#     prov:generatedAtTime. A note that flows into grounding as
+#     caregiver-reported evidence carries this provenance with it.
+#   - a follow-up is ADDITIONALLY typed cal:Vtodo and reuses W3C RDF Calendar
+#     terms: ical:due (optional expected-completion date) and ical:status
+#     (REQUIRED; the RFC 5545 VTODO enum "NEEDS-ACTION" / "IN-PROCESS" /
+#     "COMPLETED" / "CANCELLED"). No due-date or status property is minted:
+#     a follow-up genuinely is a to-do. (schema:dueDate was considered and
+#     rejected — it does not exist; schema.org defines only paymentDueDate.)
+#
+# Pod placement: notes/ top-level container (pod-structure.md §5.2), separate
+# from annotations/ (the record-amendment overlays above are edit MACHINERY;
+# notes/ is user-authored content).
+# ============================================================================
+
+workbench:followUp a owl:NamedIndividual, oa:Motivation ;
+    rdfs:label "follow up"@en ;
+    skos:prefLabel "follow up"@en ;
+    skos:broader oa:questioning ;
+    rdfs:comment "The motivation of a follow-up / open loop: an annotation that names something the caregiver intends to resolve later (e.g. \"recheck TSH in 3 months\"). Minted per the Web Annotation model's extension rule (a custom motivation SHOULD be a skos:Concept with skos:broader to a standard one); oa:questioning is the nearest standard motivation — an open question awaiting resolution. An annotation motivated by workbench:followUp is dual-typed cal:Vtodo and carries ical:status (required) + ical:due (optional). Candidate to graduate to a shared layer if other Cascade apps adopt the open-loops worklist."@en ;
+    owl:versionInfo "Added in workbench v1-draft.0.5" .
 
 # ============================================================================
 # Append-only record amendment overlays

--- a/pod-structure.md
+++ b/pod-structure.md
@@ -371,6 +371,23 @@ wellness/
       test-{id}.ttl            # Individual pots:POTSTest results
 ```
 
+**Cascade Workbench** adds these directories (vocabulary: `workbench/v1-draft`):
+
+```
+notes/
+  {id}.ttl                    # oa:Annotation resources: user-authored notes,
+                              # research flags, and follow-ups over records,
+                              # claims, or investigations (workbench v1-draft.0.5;
+                              # W3C Web Annotation + PROV-O attribution; follow-ups
+                              # dual-typed cal:Vtodo with ical:due / ical:status)
+
+annotations/
+  {id}.ttl                    # workbench: append-only record-amendment overlays
+                              # (Amendment / Annotation / Retraction / Tombstone)
+                              # -- edit machinery, deliberately separate from the
+                              # user-authored content in notes/
+```
+
 **Hypothetical diabetes management app:**
 
 ```


### PR DESCRIPTION
Promotes the Workbench proposal `2026-07-13-notes-as-web-annotations.md` ([NOTES-ANNOTATION-VOCAB]) into `workbench/v1-draft`. Unblocks shell Phase 9.

## Design (redline the three decided questions)

Caregiver notes, "needs research" flags, and follow-ups are ONE artifact: an `oa:Annotation` over one or more graph nodes, distinguished by `oa:motivatedBy` (commenting / questioning / `workbench:followUp`). Required PROV-O attribution (`prov:wasAttributedTo` + `prov:generatedAtTime`) so a note can flow into grounding as caregiver-reported evidence. Span selectors (`oa:TextQuoteSelector` / `oa:TextPositionSelector`) pin notes to passages, the same byte-verified-span idea the Claims Ledger uses.

The proposal's three open questions, decided as discussed:

1. **Pod placement** -> new top-level `notes/` container (`pod-structure.md` 5.2), deliberately separate from `annotations/` (record-amendment overlays are edit machinery; `notes/` is user content).
2. **Follow-up due/status** -> full standards reuse, better than the proposal's own candidate: `schema:dueDate` **does not exist** (verified 404 at schema.org/dueDate; schema.org has only `paymentDueDate`), so follow-ups are dual-typed `cal:Vtodo` and reuse W3C RDF Calendar `ical:due` (optional) + `ical:status` (required, RFC 5545 enum NEEDS-ACTION / IN-PROCESS / COMPLETED / CANCELLED). Zero minted date/status terms.
3. **Evidence overlap** -> none today (verified: `evidence/v1-draft` has no `oa:` usage); the notes-as-evidence seam is documented in the usage profile, no evidence restructure in this pass.

**Exactly one term minted:** `workbench:followUp`, an `oa:Motivation` with `skos:broader oa:questioning`, per the OA model's custom-motivation extension rule.

**Removed (draft policy):** `workbench:InvestigationNote` / `hasNote` / `noteText` -- never emitted by shipping code (only type declarations in the Workbench contracts package, cleanup rides with Phase 9). An investigation-scoped note is an annotation targeting the Investigation.

## Verification

- Both TTL files parse (N3, 270 + 161 triples).
- **Shapes proven against the real validator** (`cascade validate --shapes`): a valid fixture (multi-target commenting note, selector-anchored questioning flag, Vtodo follow-up) PASSES; the negative fixture FAILS with all three intended violation classes (followUp-without-status, commenting-without-body, floating annotation missing target + attribution). SHACL Core only, same posture as the evidence grounding invariant.
- Pre-commit hook satisfied (versionInfo bump 0.4 -> 0.5, dct:modified, changelog block).

## Downstream

Batched: `PENDING_DOWNSTREAM_SYNC.md` gains row 3 (unchecked boxes for site / conformance / cli shapes / SDKs / agent), to be run in ONE batch together with the outstanding `userSourceLabel` + `evidence:` facet-model rows -- the ledger's designed release boundary. Drafts stay out of `VOCAB_VERSIONS`; no JSON-LD context until v1.0 graduation. Tag `vocab/workbench-v1-draft.0.5` after merge.

Note: the top-level CHANGELOG.md was missing milestones for v1-draft.0.4 and the evidence facet model (per-vocab changelogs + ledger carried them); this PR adds only its own milestone -- backfill can ride with the batch sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)