### PR TITLE
docs(schema): close out the 2026-07-15 batched draft sync (ledger + changelog backfill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ Tag: `vocab/workbench-v1-draft.0.5` (applied after merge). See `ontologies/workb
 
 ---
 
+## 2026-07-01 — evidence v1-draft.0.2 (verdict taxonomy v2: the facet model)
+
+The `evidence:` grounding outcome moves from the flat 4-value `evidence:verdict` to orthogonal **facets** on the Assertion: `evidence:direction` / `basis` / `strength` / `settled` / `reason` (object properties over new closed enumerations `DirectionValue` / `BasisValue` / `StrengthValue` / `SettledValue` / `NeedsEvidenceReasonValue`) plus `evidence:confidence` (`xsd:decimal`, [0,1]). The facets are the canonical serialized form. The generalized SHACL-Core grounding invariant: a grounded result (settled Settled, non-None direction, non-None basis) of EITHER basis requires at least one `evidence:hasEvidenceLink`, plus facet-consistency constraints (NeedsEvidence must not carry a grounded direction; a grounded direction requires a real basis). Some individuals are shared across facets (e.g. `Supports`/`Contradicts` are both `StanceValue` and `DirectionValue`; `None` is both `DirectionValue` and `BasisValue`; `NeedsLiterature` doubles as the deprecated `VerdictValue` and a `NeedsEvidenceReasonValue`). `evidence:verdict` and the `VerdictValue` individuals are **deprecated, not removed**, kept one release so draft-period data still validates; both are scheduled for removal at v1.0 graduation (see `PENDING_DOWNSTREAM_SYNC.md`).
+
+Tag: `vocab/evidence-v1-draft.0.2` (applied after merge). See `ontologies/evidence/CHANGELOG.md`. Downstream propagation is BATCHED per `PENDING_DOWNSTREAM_SYNC.md` (row 2), synced 2026-07-15 together with the outstanding v1-draft rows.
+
+---
+
+## 2026-06-28 — workbench v1-draft.0.4 (userSourceLabel filing axis)
+
+Adds the filing / organization axis to `workbench:`: `workbench:userSourceLabel` (`xsd:string`), the user-chosen label for the SOURCE a record is filed under in the Workbench "filing cabinet". It is a filing preference attributed to the user, carried on a `workbench:Annotation` overlay (`annotationProperty` = `"workbench:userSourceLabel"`, `annotationValue` = the chosen label) bearing `cascade:SelfReported` provenance. It MUST NOT overwrite the objective imported origin `clinical:sourceEHR`, which is preserved and displayed alongside; the effective grouping source prefers this label, else falls back to `clinical:sourceEHR` / the import-batch tag. Orthogonal axis with an open domain (mirroring `workbench:verificationStatus` in v1-draft.0.3), so it can file any record. No new SHACL shape: the overlay reuses the already-shaped `workbench:annotationProperty` / `workbench:annotationValue` string predicates.
+
+Tag: `vocab/workbench-v1-draft.0.4` (applied after merge). See `ontologies/workbench/CHANGELOG.md`. Downstream propagation is BATCHED per `PENDING_DOWNSTREAM_SYNC.md` (row 1), synced 2026-07-15 together with the outstanding v1-draft rows.
+
+---
+
 ## 2026-05-06 — genomics v1-draft.0.3 (shape relaxations from test-fixture review)
 
 Two SHACL shape relaxations on `genomics/v1-draft`. No vocabulary additions; shapes only.

--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -36,86 +36,100 @@ on the CLI shape sync; do it promptly only so `validate` documents the new term.
 
 ---
 
-## Open items
+## Done — batched sync 2026-07-15
 
-### 1. `workbench:userSourceLabel` (draft) — authored, downstream pending
+The three v1-draft rows below were propagated in one batch (Vocabulary Change
+Checklist steps 2–7). One PR per repo; every box is checked with its PR number.
+Drafts stay UNROWED in `VOCAB_VERSIONS` per D-PATH (each SDK/repo added a dated
+comment only), so the released-vocab drift check still reads UP TO DATE across
+all repos. Tags `vocab/workbench-v1-draft.0.5`, `vocab/workbench-v1-draft.0.4`,
+and `vocab/evidence-v1-draft.0.2` are applied on merge.
+
+**Per-repo PRs (shared across the three rows):**
+
+| Repo | PR | What synced |
+|---|---|---|
+| cascade-cli | the-cascade-protocol/cascade-cli#16 | embedded `evidence` + `workbench` shapes (`sync-shapes-from-spec.sh`); 992 tests green; note fixtures verified against the embedded shapes |
+| cascadeprotocol.org | the-cascade-protocol/cascadeprotocol.org#2 | `evidence/v1-draft` + `workbench/v1-draft` docs (HTML + `cascade-protocol-schemas.md`), `sync-from-spec.sh` + `generate-llms.sh` draft loops, regenerated `llms-full.txt` |
+| conformance | the-cascade-protocol/conformance#2 | `fixtures/evidence/` (six facet fixtures) + `fixtures/workbench/` (six note fixtures + one filing-label fixture) with INVENTORY.md; all 14 proven PASS/FAIL against the real validator |
+| sdk-typescript | the-cascade-protocol/sdk-typescript#2 | `oa`/`ical`/`skos`/`workbench`/`evidence` namespaces + facet/`userSourceLabel` predicates; drafts excluded from the generated JSON-LD context; 408 tests pass |
+| sdk-python | the-cascade-protocol/sdk-python#1 | same namespaces + predicates (snake + camel); VOCAB_VERSIONS draft comment; 207 tests pass |
+| cascade-agent | the-cascade-protocol/cascade-agent#13 | system-prompt query patterns for the `notes/` container, evidence facets, and `userSourceLabel`; VOCAB_VERSIONS draft comment |
+
+### 1. `workbench:userSourceLabel` (draft, v1-draft.0.4) — DONE
 
 - **Authored:** `spec/ontologies/workbench/v1-draft/workbench.ttl` (DatatypeProperty,
-  `owl:versionInfo 1.0-draft.0.4`, `dct:modified 2026-06-28`). DONE.
+  `owl:versionInfo 1.0-draft.0.4`, `dct:modified 2026-06-28`).
 - **What it is:** the user's chosen filing label for a record (the editable-source
   "File under source" action), folded by the app as an annotation. Distinct from
   the imported `clinical:sourceEHR`.
 - **Downstream:**
-  - [ ] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md`
-  - [ ] conformance — fixture exercising a re-filed record
-  - [ ] cascade-cli — embedded `workbench` shapes (currently emitted via generic
-        `pod annotate --property`; validates open-world, no shape change required to ship)
-  - [ ] sdk-typescript / sdk-python — predicate + context
-  - [ ] cascade-agent — query patterns
-  - **Batchable:** yes (draft; open-world).
+  - [x] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md` (#2)
+  - [x] conformance — `filing-label-refile.VALID.ttl` re-filed-record fixture (#2)
+  - [x] cascade-cli — embedded `workbench` shapes (cascade-cli#16); validates open-world, no shape change required to ship
+  - [x] sdk-typescript / sdk-python — predicate registered (sdk-typescript#2 / sdk-python#1)
+  - [x] cascade-agent — query pattern (#13)
 
-### 2. `evidence:` verdict taxonomy v2 facet model (draft) — authored, downstream pending
+### 2. `evidence:` verdict taxonomy v2 facet model (draft, v1-draft.0.2) — DONE
 
 - **Authored:** `spec/ontologies/evidence/v1-draft/evidence.ttl` +
   `evidence.shapes.ttl` (`owl:versionInfo 1.0-draft.0.2`, `dct:modified
-  2026-07-01`, tag `vocab/evidence-v1-draft.0.2`). DONE.
+  2026-07-01`, tag `vocab/evidence-v1-draft.0.2`).
 - **What it is:** the grounding outcome moves from the flat 4-value
   `evidence:verdict` to orthogonal facets on the Assertion
   (`evidence:direction` / `basis` / `strength` / `settled` / `reason` object
   properties over closed enumerations, `evidence:confidence` xsd:decimal).
   The facets are the canonical serialized form; the SHACL grounding invariant
-  is generalized (SHACL Core): a grounded result of EITHER basis requires
-  >= 1 evidence link, plus facet-consistency constraints. `evidence:verdict`
-  and the `VerdictValue` individuals are deprecated, kept one release.
+  is generalized (SHACL Core). `evidence:verdict` and the `VerdictValue`
+  individuals are deprecated, kept one release.
 - **Code sync (already done in lockstep, not batched):**
   `cascade-workbench/packages/contracts` (invariant + migration) and
   `packages/claims` `reify()`; Workbench grounding-gate fixtures exercise the
   new shapes against the real validator.
 - **Downstream:**
-  - [ ] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md`
-  - [ ] conformance — facet fixtures (grounded-without-link INVALID,
-        NeedsEvidence-with-grounded-direction INVALID, either-basis VALID);
-        interim copies live in `cascade-workbench/fixtures/grounding/`
-  - [ ] cascade-cli — embedded `evidence` shapes via `sync-shapes-from-spec.sh`
-        (Workbench passes its own synced copy via `--shapes` meanwhile)
-  - [ ] sdk-typescript / sdk-python — facet predicates + context
-  - [ ] cascade-agent — query patterns
-  - **Batchable:** yes (draft; open-world).
+  - [x] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md` (#2)
+  - [x] conformance — facet fixtures ported from the grounding-gate set (#2)
+  - [x] cascade-cli — embedded `evidence` shapes via `sync-shapes-from-spec.sh` (cascade-cli#16)
+  - [x] sdk-typescript / sdk-python — facet predicates (sdk-typescript#2 / sdk-python#1)
+  - [x] cascade-agent — query patterns (#13)
 - **At v1.0 graduation (do NOT batch-forget):** remove `evidence:verdict` +
   the `VerdictValue` individuals and the legacy SHACL branch; make
   `evidence:settled` `sh:minCount 1`; drop the derived legacy `Verdict` from
-  `@cascade-workbench/contracts`.
+  `@cascade-workbench/contracts`. Also: mint the JSON-LD context for `evidence:`
+  and remove the `DRAFT_CONTEXT_EXCLUDED_PREFIXES` guard in sdk-typescript.
 
-### 3. `workbench:` notes / flags / follow-ups as Web Annotations (draft) — authored, downstream pending
+### 3. `workbench:` notes / flags / follow-ups as Web Annotations (draft, v1-draft.0.5) — DONE
 
 - **Authored:** `spec/ontologies/workbench/v1-draft/workbench.ttl` +
   `workbench.shapes.ttl` (`owl:versionInfo 1.0-draft.0.5`, `dct:modified
-  2026-07-15`, tag `vocab/workbench-v1-draft.0.5` after merge) +
-  `pod-structure.md` §5.2 `notes/` container. DONE.
+  2026-07-15`, tag `vocab/workbench-v1-draft.0.5`) + `pod-structure.md` §5.2
+  `notes/` container.
 - **What it is:** [NOTES-ANNOTATION-VOCAB] — caregiver notes, research flags,
   and follow-ups as ONE `oa:Annotation` substrate distinguished by
   `oa:motivatedBy`; required PROV-O attribution; follow-ups dual-typed
   `cal:Vtodo` with `ical:due` / `ical:status`. One minted term
-  (`workbench:followUp`). `InvestigationNote` removed (unshipped). Unblocks
-  Workbench shell Phase 9.
+  (`workbench:followUp`). `InvestigationNote` removed (unshipped).
 - **Code sync (lockstep, not batched):** Workbench Phase 9 emits/reads these
   under `notes/`; the contracts package drops the stale `InvestigationNote`
   types in the same PR.
 - **Downstream:**
-  - [ ] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md`
-  - [ ] conformance — fixtures: valid commenting/questioning/followUp notes
-        (multi-target + selector-anchored + Vtodo); INVALID
-        followUp-without-status, commenting-without-body, floating annotation
-        (recreate from the shapes-verification set in the authoring PR)
-  - [ ] cascade-cli — embedded `workbench` shapes via `sync-shapes-from-spec.sh`
-        (open-world: Phase 9 can ship before this lands; sync promptly so
-        `cascade validate` enforces the note shapes by default)
-  - [ ] sdk-typescript / sdk-python — `oa:`/`ical:` predicates + namespaces
-  - [ ] cascade-agent — query patterns (`notes/` container, motivation filters)
-  - **Batchable:** yes (draft; open-world). No JSON-LD context yet (drafts get
-    contexts at v1.0 graduation, same as the other draft rows).
+  - [x] cascadeprotocol.org — `sync-from-spec.sh`, HTML + `cascade-protocol-schemas.md` (#2)
+  - [x] conformance — valid commenting/questioning/followUp notes + INVALID
+        followUp-without-status, commenting-without-body, floating annotation (#2)
+  - [x] cascade-cli — embedded `workbench` shapes via `sync-shapes-from-spec.sh` (cascade-cli#16)
+  - [x] sdk-typescript / sdk-python — `oa:`/`ical:`/`skos:` predicates + namespaces
+        (`workbench:followUp` is a motivation individual, reached via the namespace;
+        sdk-typescript#2 / sdk-python#1)
+  - [x] cascade-agent — query patterns (`notes/` container, motivation filters) (#13)
+- **JSON-LD context:** none yet (drafts get contexts at v1.0 graduation, same as
+  the other draft rows; sdk-typescript explicitly excludes draft prefixes from
+  the generated context until then).
 
-### 4. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
+---
+
+## Open items
+
+### 1. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
 
 - **Status:** DEFERRED from the 2026-06-28 source-attribution work. The Apple
   Health authoritative-`sourceName` fix (importer reads `export.xml`


### PR DESCRIPTION
Closes the loop on the batched downstream propagation of the three v1-draft rows in `PENDING_DOWNSTREAM_SYNC.md` (Vocabulary Change Checklist steps 2-7, run once for all three).

## Ledger (`PENDING_DOWNSTREAM_SYNC.md`)

Rows 1-3 moved to a new **Done** section, every box checked with its PR number:

| Row | Change | Propagated by |
|---|---|---|
| 1 | `workbench:userSourceLabel` (v1-draft.0.4) | site#2, conformance#2, cli#16, sdk-ts#2, sdk-py#1, agent#13 |
| 2 | `evidence:` verdict-taxonomy-v2 facet model (v1-draft.0.2) | site#2, conformance#2, cli#16, sdk-ts#2, sdk-py#1, agent#13 |
| 3 | `workbench:` notes / flags / follow-ups Web Annotations (v1-draft.0.5) | site#2, conformance#2, cli#16, sdk-ts#2, sdk-py#1, agent#13 |

Only the deferred `clinical:sourceSystemOID` row remains open. The evidence row keeps its "do NOT batch-forget at v1.0 graduation" reminder (now also flags minting the JSON-LD context and removing the sdk-typescript draft-context exclusion).

## Changelog backfill (`CHANGELOG.md`)

Added the two missing top-level milestones, summarized from their per-vocab changelogs:
- **2026-07-01 — evidence v1-draft.0.2** (facet model, generalized SHACL-Core grounding invariant, `evidence:verdict` deprecated one release).
- **2026-06-28 — workbench v1-draft.0.4** (`userSourceLabel` filing axis, no new shape).

(The 2026-07-15 workbench v1-draft.0.5 milestone was already present.)

## Drift check

`sh scripts/check-downstream-versions.sh`:

```
Canonical vocab versions (spec):
  core = 3.3
  health = 2.4
  clinical = 1.9
  coverage = 1.3
  checkup = 3.2
  pots = 1.4

[cascade-cli] UP TO DATE
[sdk-typescript] UP TO DATE
[sdk-python] UP TO DATE
[cascade-agent] UP TO DATE
[conformance] UP TO DATE
[cascadeprotocol.org] UP TO DATE
[cascade-sdk-swift] UP TO DATE

All downstream repos are in sync.
```

Drafts stay UNROWED in `VOCAB_VERSIONS` per D-PATH (each repo added a dated comment only), so the released-vocab rows all still read UP TO DATE.

## Tags (applied on merge)

`vocab/workbench-v1-draft.0.5`, `vocab/workbench-v1-draft.0.4`, `vocab/evidence-v1-draft.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)