### PR TITLE
docs(schema): clinical: graph edge vocabulary + hasLabResult range fix (v1.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: each entry is one milestone, dated, with a short prose summary and point
 
 ---
 
+## 2026-07-16: clinical v1.9 to v1.10 (graph edge vocabulary)
+
+Gives the importer traversable RDF for the relationships EHR sources carry but the pod has been flattening. Four authored changes to the released `clinical` vocabulary (slice V1 of the graph-retrieval sequenced plan; root backlog 3.12 and 3.11(d); blocks importer slice R3):
+
+- `clinical:hasEncounter` (ObjectProperty, range `clinical:Encounter`): the record-to-encounter edge for grouping clinical events by visit context. FHIR-aligned to the `.encounter` Reference(Encounter) element on Observation, MedicationRequest, Condition, Procedure, DiagnosticReport, DocumentReference. Broad domain, constrained by SHACL rather than a restrictive `rdfs:domain` union.
+- `clinical:indicationReference` (ObjectProperty, open range `rdfs:Resource`): the medication-to-condition indication edge, alongside the retained free-text `clinical:indication` / `clinical:reasonForUse` literals. FHIR-aligned to `MedicationRequest.reasonReference` (R4; `reason` CodeableReference in R5). Range left open because FHIR allows Condition or Observation.
+- `clinical:linkedCondition` (ObjectProperty, Condition to Condition) plus `owl:deprecated true` on `clinical:linkedConditionIds`. Replaces the space-separated-UUID literal wart with a real traversable edge; the old property is retained (not removed) for backward compatibility with existing Checkup data.
+- `clinical:hasLabResult` `rdfs:range` corrected from `clinical:LabResult` to `health:LabResultRecord`, matching the class both importer paths actually type panel members (root 3.11(d)). Non-breaking (no SHACL shape constrained the edge target). Surfaced a related gap: `health:LabResultRecord` is emitted by the importer but has no class definition in the health vocabulary, filed as a follow-up.
+
+Shapes: three open-world `sh:targetSubjectsOf` PropertyShapes (IRI nodeKind, class where the range is committed, `sh:Warning`, no `minCount`), so no pod current or future fails validation on account of these edges. JSON-LD context: the three ObjectProperties as `@type: @id`.
+
+Tag: `vocab/clinical-v1.10` (applied after merge). See the inline changelog in `ontologies/clinical/v1/clinical.ttl`. The `cascade-cli` shape sync ships promptly in its own PR so `cascade validate` knows the terms; the rest of the 7-repo checklist (docs site, conformance, both SDKs, agent) is BATCHED per `PENDING_DOWNSTREAM_SYNC.md` (Pending batch, clinical v1.10).
+
+---
+
 ## 2026-07-15 — workbench v1-draft.0.5 (notes / flags / follow-ups as W3C Web Annotations)
 
 Caregiver notes, "needs research" flags, and follow-ups become ONE substrate: `oa:Annotation` over one or more graph nodes, distinguished by `oa:motivatedBy`, with required PROV-O attribution. Maximal Layer-1 reuse: span selectors from `oa:`, due date + status for follow-ups from W3C RDF Calendar (`ical:due` / `ical:status`, follow-ups dual-typed `cal:Vtodo`). Exactly one term minted: `workbench:followUp` (an `oa:Motivation`, `skos:broader oa:questioning`). `workbench:InvestigationNote` removed (draft; unshipped), superseded by the substrate. New Pod container `notes/` documented in `pod-structure.md` §5.2. SHACL Core shapes verified against `cascade validate` with positive + negative fixtures. Unblocks Workbench shell Phase 9 (notes grammar).

--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -127,6 +127,62 @@ and `vocab/evidence-v1-draft.0.2` are applied on merge.
 
 ---
 
+## Pending batch — clinical v1.10 (authored 2026-07-16)
+
+Released-vocab change (`clinical` 1.9 to 1.10), tag `vocab/clinical-v1.10`. Per
+the seam table, `spec/` + the `cascade-cli` shape sync happen NOW (so `cascade
+validate` knows the terms); the rest of the 7-repo checklist BATCHES here and
+runs at the next release boundary. Open-world shapes mean the DATA can ship
+before this batch fires. Slice V1 of the graph-retrieval sequenced plan
+(root backlog 3.12 + 3.11(d)); it blocks importer slice R3.
+
+**What was authored (the four changes):**
+
+- `clinical:hasEncounter` ObjectProperty (range `clinical:Encounter`) — the
+  record-to-encounter edge. FHIR: the `.encounter` Reference(Encounter) element
+  on Observation/MedicationRequest/Condition/Procedure/DiagnosticReport/
+  DocumentReference.
+- `clinical:indicationReference` ObjectProperty (range `rdfs:Resource`, open) —
+  the medication-to-condition indication edge, alongside the retained free-text
+  `clinical:indication` / `clinical:reasonForUse`. FHIR: `MedicationRequest.reasonReference`.
+- `clinical:linkedCondition` ObjectProperty (Condition to Condition) plus
+  `owl:deprecated true` on `clinical:linkedConditionIds` (the space-separated
+  UUID literal it replaces; retained for backward compatibility).
+- `clinical:hasLabResult` `rdfs:range` corrected `clinical:LabResult` to
+  `health:LabResultRecord` (root 3.11(d)) to match what both importer paths
+  actually type.
+- Shapes: three open-world `sh:targetSubjectsOf` PropertyShapes (IRI nodeKind,
+  class where committed, `sh:Warning`, no minCount). JSON-LD context: the three
+  new ObjectProperties as `@type: @id`.
+
+**Synced NOW (not batched):**
+
+- [x] `spec/` — authored (this repo); `VOCAB_VERSIONS` `clinical=1.10`.
+- [x] `cascade-cli` — `sync-shapes-from-spec.sh` (embedded `clinical.ttl` +
+      `clinical.shapes.ttl`) + `VOCAB_VERSIONS` `clinical=1.10`. PR: `<CLI-PR>`.
+
+**Batched (do NOT execute now; run at the next batch, per CLAUDE.md checklist 2-7):**
+
+- [ ] `cascadeprotocol.org` — `sync-from-spec.sh`, HTML docs (`docs/clinical/v1/`
+      version refs, new property/shape sections, changelog entry) +
+      `cascade-protocol-schemas.md` heading/property-count/version-history +
+      `docs/index.html` clinical card badge; regenerate `llms-full.txt`.
+- [ ] `conformance` — fixtures for `hasEncounter` / `indicationReference` /
+      `linkedCondition` (VALID edge + INVALID non-IRI / wrong-class), plus a
+      `hasLabResult`→`health:LabResultRecord` range fixture; tag a release.
+- [ ] `sdk-typescript` — register the three predicates (`@type: @id`) + the
+      `health:LabResultRecord` range in the generated context; `VOCAB_VERSIONS`.
+- [ ] `sdk-python` — same predicates (snake + camel) + namespaces; `VOCAB_VERSIONS`.
+- [ ] `cascade-agent` — system-prompt query patterns for encounter-grouped
+      records, medication indications, and condition links; `VOCAB_VERSIONS`.
+
+**At the batch: `check-downstream-versions.sh` should report `clinical` drift
+(repo=1.9, spec=1.10) for cascadeprotocol.org, sdk-typescript, sdk-python,
+cascade-agent, conformance, and cascade-sdk-swift until each is brought current;
+cascade-cli reads 1.10 immediately after its shape-sync PR merges.**
+
+---
+
 ## Open items
 
 ### 1. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
@@ -138,12 +194,13 @@ and `vocab/evidence-v1-draft.0.2` are applied on merge.
 - **What it would be:** carry the raw source-system OID (e.g.
   `urn:oid:1.2.840.114350.1.13.296` = an Epic customer org) alongside the friendly
   `clinical:sourceEHR`, as supplementary provenance + a stable cross-export key for
-  reconciliation and the OID→org registry. `clinical:` is a RELEASED vocab (1.9),
-  so authoring it bumps `clinical` to 1.10 and triggers the CLI shape sync.
+  reconciliation and the OID→org registry. `clinical:` is a RELEASED vocab (now
+  1.10 after the edge-vocab batch above), so authoring it bumps `clinical` to
+  1.11 and triggers the CLI shape sync.
 - **Trigger to author:** a non-Apple import (raw FHIR / C-CDA with no Apple
   wrapper) needs OID-based attribution, OR the OID→org registry work begins.
 - **Downstream when authored:** full 7-repo checklist (released vocab).
 
 ---
 
-_Last updated: 2026-07-15._
+_Last updated: 2026-07-16._

--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -159,7 +159,9 @@ before this batch fires. Slice V1 of the graph-retrieval sequenced plan
 
 - [x] `spec/` — authored (this repo); `VOCAB_VERSIONS` `clinical=1.10`.
 - [x] `cascade-cli` — `sync-shapes-from-spec.sh` (embedded `clinical.ttl` +
-      `clinical.shapes.ttl`) + `VOCAB_VERSIONS` `clinical=1.10`. PR: `<CLI-PR>`.
+      `clinical.shapes.ttl`) + `VOCAB_VERSIONS` `clinical=1.10`. PR:
+      the-cascade-protocol/cascade-cli#21 (npm test 1034 green; fresh Synthea
+      import validates 20/20 clean against the new shapes).
 
 **Batched (do NOT execute now; run at the next batch, per CLAUDE.md checklist 2-7):**
 

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -4,7 +4,7 @@
 # Format: {vocab}={major}.{minor}
 core=3.3
 health=2.4
-clinical=1.9
+clinical=1.10
 coverage=1.3
 checkup=3.2
 pots=1.4

--- a/contexts/v1/clinical.jsonld
+++ b/contexts/v1/clinical.jsonld
@@ -2,6 +2,7 @@
   "@context": {
     "clinical": "https://ns.cascadeprotocol.org/clinical/v1#",
     "cascade": "https://ns.cascadeprotocol.org/core/v1#",
+    "health": "https://ns.cascadeprotocol.org/health/v1#",
     "fhir": "http://hl7.org/fhir/",
     "sct": "http://snomed.info/sct/",
     "loinc": "http://loinc.org/rdf#",
@@ -350,6 +351,19 @@
       "@id": "clinical:alcoholDrinksPerWeek",
       "@type": "xsd:decimal"
     },
-    "occupationTitle": "clinical:occupationTitle"
+    "occupationTitle": "clinical:occupationTitle",
+
+    "hasEncounter": {
+      "@id": "clinical:hasEncounter",
+      "@type": "@id"
+    },
+    "indicationReference": {
+      "@id": "clinical:indicationReference",
+      "@type": "@id"
+    },
+    "linkedCondition": {
+      "@id": "clinical:linkedCondition",
+      "@type": "@id"
+    }
   }
 }

--- a/ontologies/clinical/v1/clinical.shapes.ttl
+++ b/ontologies/clinical/v1/clinical.shapes.ttl
@@ -13,6 +13,12 @@
 # different data sources (EHR, device, patient-reported).
 #
 # Changelog:
+# v1.10 (2026-07-16): Add open-world PropertyShapes for the three record-to-record
+#     edges introduced in clinical v1.10 (hasEncounter, indicationReference,
+#     linkedCondition). Each targets the subjects that use the predicate, checks
+#     only that the object is an IRI (plus its class where the range is
+#     committed), asserts no minCount, and reports at sh:Warning severity so no
+#     pod, current or future, fails validation on account of these edges.
 # v1.9 (2026-06-17): Add cascade:AIExtracted to every dataProvenance sh:in enum.
 #     AIExtracted (a ClinicalGenerated subclass, core v3.3) was defined and
 #     referenced by the v3.0 AI-extraction infrastructure, but the validation
@@ -1385,8 +1391,52 @@ clinical:SocialHistoryRecordShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Graph Edge Property Shapes (v1.10)
+# Open-world, non-required constraints for the record-to-record edges added in
+# clinical v1.10. Each targets the subjects that USE the predicate (so nothing
+# fires unless the edge is present) and checks only that the object is an IRI
+# (plus its class where the range is committed). Nothing is sh:closed, no
+# minCount is asserted, and severity is sh:Warning, so existing pods that carry
+# none of these predicates validate exactly as before, and future pods that do
+# carry them never fail validation (e.g. when an edge target lives in a sibling
+# file and sh:class cannot resolve during per-file validation).
+# ============================================================================
+
+clinical:HasEncounterEdgeShape a sh:PropertyShape ;
+    sh:targetSubjectsOf clinical:hasEncounter ;
+    sh:path clinical:hasEncounter ;
+    sh:nodeKind sh:IRI ;
+    sh:class clinical:Encounter ;
+    sh:severity sh:Warning ;
+    sh:message "clinical:hasEncounter should reference a clinical:Encounter by IRI"@en ;
+    sh:name "Has Encounter Edge"@en .
+
+clinical:IndicationReferenceEdgeShape a sh:PropertyShape ;
+    sh:targetSubjectsOf clinical:indicationReference ;
+    sh:path clinical:indicationReference ;
+    sh:nodeKind sh:IRI ;
+    sh:severity sh:Warning ;
+    sh:message "clinical:indicationReference should reference the reason record (a Condition or Observation) by IRI"@en ;
+    sh:name "Indication Reference Edge"@en .
+
+clinical:LinkedConditionEdgeShape a sh:PropertyShape ;
+    sh:targetSubjectsOf clinical:linkedCondition ;
+    sh:path clinical:linkedCondition ;
+    sh:nodeKind sh:IRI ;
+    sh:class clinical:Condition ;
+    sh:severity sh:Warning ;
+    sh:message "clinical:linkedCondition should reference a clinical:Condition by IRI"@en ;
+    sh:name "Linked Condition Edge"@en .
+
+# ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.10 (2026-07-16)
+# - Added HasEncounterEdgeShape, IndicationReferenceEdgeShape, and
+#   LinkedConditionEdgeShape: open-world PropertyShapes (sh:targetSubjectsOf)
+#   for the v1.10 record-to-record edges. IRI nodeKind, class where committed,
+#   no minCount, sh:Warning severity. Purely additive.
 #
 # Version 1.8 (2026-03-28)
 # - Added SocialHistoryRecordShape for EHR-extracted social history records

--- a/ontologies/clinical/v1/clinical.ttl
+++ b/ontologies/clinical/v1/clinical.ttl
@@ -9,6 +9,7 @@
 @prefix sct: <http://snomed.info/sct/> .
 @prefix loinc: <http://loinc.org/rdf#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
 
 # ============================================================================
 # Ontology Metadata
@@ -20,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-06-17"^^xsd:date ;
-    owl:versionInfo "1.9" ;
+    dct:modified "2026-07-16"^^xsd:date ;
+    owl:versionInfo "1.10" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -752,9 +753,11 @@ clinical:icd10Code a owl:DatatypeProperty ;
 
 clinical:linkedConditionIds a owl:DatatypeProperty ;
     rdfs:label "Linked Condition IDs"@en ;
-    rdfs:comment "Space-separated UUIDs of related ConditionSummary records (e.g., linking a complication to its root condition). Enables graph traversal between related diagnoses."@en ;
+    rdfs:comment "DEPRECATED (v1.10): use the clinical:linkedCondition ObjectProperty instead, which links to related conditions by IRI and is traversable RDF. This property encoded links as space-separated UUIDs in a single literal, which no graph query can follow. Retained for backward compatibility with existing Checkup data that may carry it; not emitted for new data."@en ;
     rdfs:domain clinical:Condition ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    owl:deprecated "true"^^xsd:boolean ;
+    rdfs:seeAlso clinical:linkedCondition .
 
 # ============================================================================
 # Data Properties - Immunization
@@ -1298,6 +1301,37 @@ clinical:isActive a owl:DatatypeProperty ;
 # Changelog
 # ============================================================================
 #
+# Version 1.10 (2026-07-16)
+# - Added clinical:hasEncounter ObjectProperty (range clinical:Encounter). The
+#   record-to-encounter edge for grouping clinical events by visit context.
+#   FHIR alignment: the .encounter Reference(Encounter) element on Observation,
+#   MedicationRequest, Condition, Procedure, DiagnosticReport, DocumentReference.
+#   Domain left broad (comment + SHACL, no restrictive rdfs:domain union).
+# - Added clinical:indicationReference ObjectProperty (range rdfs:Resource). The
+#   medication-to-condition indication edge alongside the retained free-text
+#   clinical:indication / clinical:reasonForUse literals. FHIR alignment:
+#   MedicationRequest.reasonReference (R4; reason CodeableReference in R5).
+#   Range left open because FHIR allows Condition or Observation; the importer
+#   materializes clinical:Condition.
+# - Added clinical:linkedCondition ObjectProperty (Condition to Condition) and
+#   deprecated clinical:linkedConditionIds (owl:deprecated true). The old
+#   property packed related-condition UUIDs into one space-separated literal
+#   that no graph query can traverse; linkedCondition is the real RDF edge.
+#   linkedConditionIds is retained (not removed) for backward compatibility
+#   with existing Checkup data; data migration off it is tracked in the Checkup
+#   backlog.
+# - Fixed clinical:hasLabResult rdfs:range: was clinical:LabResult, now
+#   health:LabResultRecord. Reasoning: both importer paths (FHIR and C-CDA) type
+#   panel members health:LabResultRecord, never clinical:LabResult, so the
+#   declared range described a class the data never uses. This was internally
+#   inconsistent (an OWL reasoner would have inferred members are
+#   clinical:LabResult) though non-breaking (no SHACL shape constrains the edge
+#   target). Corrected to match the serialized data. Note: health:LabResultRecord
+#   is emitted by the importer but not yet defined as a class in the health
+#   vocabulary; that gap is filed as a follow-up (health vocab), and the
+#   range here follows the same reference-an-external-class style this file
+#   already uses for fhir:/sct:/loinc: classes.
+#
 # Version 1.9 (2026-06-17)
 # - SHACL: added cascade:AIExtracted to every dataProvenance sh:in enum in
 #   clinical.shapes.ttl. AIExtracted (ClinicalGenerated subclass, core v3.3)
@@ -1568,9 +1602,9 @@ clinical:retrieveUrl a owl:DatatypeProperty ;
 
 clinical:hasLabResult a owl:ObjectProperty ;
     rdfs:label "Has Lab Result"@en ;
-    rdfs:comment "Links a LaboratoryReport panel to its constituent clinical:LabResult observations. Enables grouping of lab values (e.g., CBC components) under the ordering panel. FHIR alignment: fhir:DiagnosticReport.result."@en ;
+    rdfs:comment "Links a LaboratoryReport panel to its constituent lab-result observations. Enables grouping of lab values (e.g., CBC components) under the ordering panel. FHIR alignment: fhir:DiagnosticReport.result. Range is health:LabResultRecord (v1.10): both importer paths (FHIR and C-CDA) type panel members health:LabResultRecord, so the range is corrected to match the serialized data rather than the never-emitted clinical:LabResult class. See the v1.10 changelog for the reasoning."@en ;
     rdfs:domain clinical:LaboratoryReport ;
-    rdfs:range clinical:LabResult .
+    rdfs:range health:LabResultRecord .
 
 clinical:panelName a owl:DatatypeProperty ;
     rdfs:domain clinical:LaboratoryReport ;
@@ -1617,3 +1651,26 @@ clinical:occupationTitle a owl:DatatypeProperty ;
     rdfs:domain clinical:SocialHistoryRecord ;
     rdfs:range xsd:string ;
     rdfs:comment "Patient-reported occupation title from EHR social history section."@en .
+
+# ============================================================================
+# Graph Edge Object Properties (v1.10)
+# Traversable RDF edges the importer (R3) will materialize: encounter grouping,
+# medication indication, and condition-to-condition links. Each is FHIR-aligned.
+# ============================================================================
+
+clinical:hasEncounter a owl:ObjectProperty ;
+    rdfs:label "Has Encounter"@en ;
+    rdfs:comment "Links a clinical record to the clinical:Encounter (visit context) it occurred within. FHIR alignment: the .encounter element (Reference(Encounter)) carried by Observation, MedicationRequest, Condition, Procedure, DiagnosticReport, and DocumentReference. The domain is intentionally broad (any encounter-scoped clinical record), so it is left unrestricted here and constrained by SHACL rather than a restrictive rdfs:domain union, matching the style of other cross-class properties in this vocabulary."@en ;
+    rdfs:range clinical:Encounter .
+
+clinical:indicationReference a owl:ObjectProperty ;
+    rdfs:label "Indication Reference"@en ;
+    rdfs:comment "Links a medication record to the condition (or observation) that is the clinical reason for it: the traversable edge alongside the free-text clinical:indication and clinical:reasonForUse literals, which are retained. FHIR alignment: MedicationRequest.reasonReference (R4), folded into MedicationRequest.reason as a CodeableReference in R5. The range is left open (rdfs:Resource) because FHIR permits either a Condition or an Observation as the reason; the common case, and what the importer materializes, is a clinical:Condition. SHACL constrains the object to an IRI without committing the class."@en ;
+    rdfs:domain clinical:Medication ;
+    rdfs:range rdfs:Resource .
+
+clinical:linkedCondition a owl:ObjectProperty ;
+    rdfs:label "Linked Condition"@en ;
+    rdfs:comment "Links a condition to a related condition by IRI (e.g. a complication to its root condition). The traversable RDF replacement for the deprecated clinical:linkedConditionIds literal. FHIR R4 core has no first-class condition-to-condition reference; the closest precedents are the condition-dueTo and condition-occurredFollowing extensions (http://hl7.org/fhir/StructureDefinition/condition-dueTo). This property keeps the generic linked semantics of its predecessor; a more specific relation can be added later if a use case needs it."@en ;
+    rdfs:domain clinical:Condition ;
+    rdfs:range clinical:Condition .


### PR DESCRIPTION
Slice **V1** of the graph-retrieval sequenced plan (root backlog **3.12** + **3.11(d)**). Gives the importer traversable RDF for the edges slice **R3** will materialize. Authored change to the released `clinical` vocabulary: **1.9 to 1.10**, tag `vocab/clinical-v1.10` (applied on merge).

## Naming table (propose, cite, ratify)

House rule is defer to ratified standards. Each new property below lists candidates, the FHIR element it aligns to, and my recommendation. **Please pick or override in review**; the code currently ships the **Recommended** column.

| Property (shipped) | Candidates | FHIR alignment (canonical URL) | Recommendation + why |
|---|---|---|---|
| **record to encounter** | `clinical:hasEncounter` ✅ · `clinical:encounter` · `clinical:occurredDuringEncounter` | `.encounter` = Reference(Encounter) on Observation/MedicationRequest/Condition/Procedure/DiagnosticReport/DocumentReference — e.g. [Observation.encounter](https://hl7.org/fhir/R4/observation-definitions.html#Observation.encounter), [MedicationRequest.encounter](https://hl7.org/fhir/R4/medicationrequest-definitions.html#MedicationRequest.encounter) | **`hasEncounter`**. Bare `clinical:encounter` collides with the existing `encounterClass`/`encounterDate`/`encounterStart` datatype props; every other object property in this vocab uses the `has*` form (`hasLabResult`, `hasSection`). FHIR's element name is `encounter`, but this vocab already declines to copy element names literally (`hasLabResult` aligns to `DiagnosticReport.result`). |
| **medication to indication** | `clinical:indicationReference` ✅ · `clinical:reasonReference` · `clinical:treatsCondition` | [MedicationRequest.reasonReference](https://hl7.org/fhir/R4/medicationrequest-definitions.html#MedicationRequest.reasonReference) (R4; folded into `reason` as CodeableReference in R5) | **`indicationReference`**. Pairs cleanly with the existing free-text `clinical:indication` (the datatype sibling, retained) and mirrors FHIR `reasonReference`. `treatsCondition` over-commits to Condition (FHIR allows Observation too); `reasonReference` reads oddly next to our `indication`/`reasonForUse` literals. |
| **condition to condition** | `clinical:linkedCondition` ✅ · `clinical:relatedCondition` · `clinical:dueToCondition` | R4 core has no first-class Condition→Condition ref; nearest are the [condition-dueTo](http://hl7.org/fhir/StructureDefinition/condition-dueTo) and condition-occurredFollowing extensions | **`linkedCondition`**. Direct, obvious replacement for the deprecated `linkedConditionIds` (same "linked" semantics, now an IRI edge). `dueToCondition` narrows to a causal relation the old property never asserted; a specific relation can be added later. |

**Range decisions to confirm:**
- `hasEncounter` → `clinical:Encounter` (committed; SHACL `sh:class`).
- `indicationReference` → **open** (`rdfs:Resource`), because FHIR permits Condition **or** Observation as the reason. Alternative: commit to `clinical:Condition` (what R3 will actually materialize from Synthea's `reasonReference`) and widen later. I recommend leaving it open to stay FHIR-faithful and avoid a future validation regression on a released vocab. SHACL asserts IRI nodeKind only.
- `linkedCondition` → `clinical:Condition` (committed; SHACL `sh:class`).

## The four changes

1. **`clinical:hasEncounter`** — record-to-encounter ObjectProperty, range `clinical:Encounter`. Broad domain (comment + SHACL, no restrictive `rdfs:domain` union).
2. **`clinical:indicationReference`** — medication-to-condition ObjectProperty, open range. `clinical:indication` / `clinical:reasonForUse` stay as the free-text literals they are; this is the edge alongside them.
3. **`clinical:linkedCondition`** (Condition→Condition) + **`owl:deprecated true`** on `clinical:linkedConditionIds`, with `rdfs:seeAlso` pointing at the replacement. The old literal is **retained, not removed** (existing Checkup data may carry it). Data migration off it is Checkup-side (filed).
4. **`clinical:hasLabResult` range fix (root 3.11(d))** — was `rdfs:range clinical:LabResult`, now `health:LabResultRecord`. Both importer paths (FHIR and C-CDA) type panel members `health:LabResultRecord`, never `clinical:LabResult`, so the declared range described a class the data never uses. Non-breaking (no SHACL shape constrained the edge target). **Reasoning in the changelog comment.**

## Shapes / context / versioning

- **Shapes** (`clinical.shapes.ttl`): three open-world `sh:targetSubjectsOf` PropertyShapes (`sh:nodeKind sh:IRI`, `sh:class` where the range is committed, `sh:Warning`, **no `minCount`**, nothing `sh:closed`). Existing pods that carry none of these predicates validate exactly as before; future pods that carry them never fail (an edge target in a sibling file that `sh:class` cannot resolve during per-file validation is a warning, not a violation).
- **JSON-LD context** (`contexts/v1/clinical.jsonld`): the three ObjectProperties as `@type: @id`; added the `health:` prefix.
- **`VOCAB_VERSIONS`**: `clinical=1.10`.
- **Ledger** (`PENDING_DOWNSTREAM_SYNC.md`): new "Pending batch, clinical v1.10" row. `cascade-cli` shape sync ships promptly in its own PR (see below); docs site, conformance, both SDKs, and the agent **batch** at the next release boundary.

## Surprise worth surfacing

**`health:LabResultRecord` has no class definition anywhere in the spec.** The importer emits `rdf:type health:LabResultRecord` on every lab-result member (`converters-clinical.ts:334`), but the health ontology never declares the class. The range fix points at it because that is what the data actually uses (consistent with how this file already references `fhir:`/`sct:`/`loinc:` classes it does not define), and I filed a follow-up to add the class to the health vocab. Flagging in case you would rather resolve that as part of this bump.

## Verification

- `clinical.ttl`, `clinical.shapes.ttl` parse clean with n3 (1095 / 1274 triples); the three new terms are `owl:ObjectProperty`, ranges as intended, `linkedConditionIds` carries `owl:deprecated true` + `rdfs:seeAlso`, `owl:versionInfo` is `1.10`. `clinical.jsonld` is valid JSON with the three `@type: @id` terms.
- `scripts/check-downstream-versions.sh` reports `clinical 1.9→1.10` drift on exactly the repos the ledger lists as pending (cascade-cli resolved by its sync PR; the rest batched).
- No importer/app changes here (R3 consumes this next). No PHI involved.

## Scope

IN: the four vocab changes, shapes, context, versioning, ledger. OUT (per kickoff): importer changes (R3), the full 7-repo propagation now (batched), draft-vocab work, `linkedConditionIds` data migration (Checkup-side, filed).
