### PR TITLE
clinical v1.12: parsedIndicationReference (parsed-vs-stated indication basis)

### DIFF
--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -230,6 +230,56 @@ the rest batches. Slice R3 of the graph-retrieval sequenced plan (root 3.11(b)).
 
 ---
 
+## Pending batch — clinical v1.12 (authored 2026-07-20)
+
+Released-vocab change (`clinical` 1.11 to 1.12), tag `vocab/clinical-v1.12`. One
+new ObjectProperty, additive only. Per the seam table, `spec/` + the `cascade-cli`
+shape sync happen NOW; the rest batches with the v1.10/v1.11 rows above (same 7
+repos, same release boundary). Slice M1 of the graph-meaning plan.
+
+**What was authored (one property + its shape):**
+
+- `clinical:parsedIndicationReference` — `rdfs:subPropertyOf
+  clinical:indicationReference`, range `rdfs:Resource`. Marks an indication edge
+  the importer DERIVED by parsing a coded/free-text reason on a record (FHIR
+  `reasonCode`, or a `clinical:indication` / `clinical:reasonForUse` literal) and
+  matching it to a condition record in the same pod, as distinct from
+  `clinical:indicationReference` proper, which restates a `reasonReference` the
+  source explicitly carried. Subproperty modeling means one traversal over the
+  superproperty returns both families while the predicate carries the basis; no
+  reification, no RDF-star, so the edge stays a plain triple. Carries NO
+  confidence score by design: a deterministic parse of what the record says, not
+  structural/temporal inference (which stays query-time, per GM-Q2).
+- `ParsedIndicationReferenceEdgeShape` — warning-only, `sh:nodeKind sh:IRI`
+  only, no `sh:class`, matching `IndicationReferenceEdgeShape` and the v1.11
+  per-file-validation rationale (root 4.6a).
+
+Motivation (M1 Phase 0 census, counts only): a real provider export reached via
+Apple Health carried 0 `reasonReference` but 50 `reasonCode` instances on
+medication/procedure records, 25 of which resolve unambiguously to a condition
+record by exact coding identity. Those relations are dropped entirely today.
+
+**Synced NOW (not batched):**
+
+- [x] `spec/` — authored (this repo); `VOCAB_VERSIONS` `clinical=1.12`.
+- [ ] `cascade-cli` — `sync-shapes-from-spec.sh` (embedded `clinical.ttl` +
+      `clinical.shapes.ttl`) + `VOCAB_VERSIONS` `clinical=1.12`. PR: (M1 branch
+      `feat/graph-meaning-m1-literal-lifting`).
+
+**Batched (do NOT execute now; fold into the clinical v1.10/v1.11 batch above):**
+
+- [ ] `cascadeprotocol.org` — HTML docs + `cascade-protocol-schemas.md`: document
+      the stated-vs-parsed indication distinction and the subproperty relation.
+- [ ] `conformance` — add a VALID `parsedIndicationReference` edge fixture
+      (medication subject to condition target) alongside the v1.11 fixtures.
+- [ ] `sdk-typescript` / `sdk-python` — register the new predicate; bump
+      `VOCAB_VERSIONS` `clinical=1.12`.
+- [ ] `cascade-agent` — teach the indication query pattern that the parsed
+      variant exists and must be labeled differently in answers; bump
+      `VOCAB_VERSIONS`.
+
+---
+
 ## Open items
 
 ### 1. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred
@@ -250,4 +300,4 @@ the rest batches. Slice R3 of the graph-retrieval sequenced plan (root 3.11(b)).
 
 ---
 
-_Last updated: 2026-07-16._
+_Last updated: 2026-07-20._

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -4,7 +4,7 @@
 # Format: {vocab}={major}.{minor}
 core=3.3
 health=2.4
-clinical=1.11
+clinical=1.12
 coverage=1.3
 checkup=3.2
 pots=1.4

--- a/contexts/v1/clinical.jsonld
+++ b/contexts/v1/clinical.jsonld
@@ -364,6 +364,10 @@
     "linkedCondition": {
       "@id": "clinical:linkedCondition",
       "@type": "@id"
+    },
+    "parsedIndicationReference": {
+      "@id": "clinical:parsedIndicationReference",
+      "@type": "@id"
     }
   }
 }

--- a/ontologies/clinical/v1/clinical.shapes.ttl
+++ b/ontologies/clinical/v1/clinical.shapes.ttl
@@ -1435,9 +1435,26 @@ clinical:LinkedConditionEdgeShape a sh:PropertyShape ;
     sh:message "clinical:linkedCondition should reference a clinical:Condition by IRI"@en ;
     sh:name "Linked Condition Edge"@en .
 
+clinical:ParsedIndicationReferenceEdgeShape a sh:PropertyShape ;
+    sh:targetSubjectsOf clinical:parsedIndicationReference ;
+    sh:path clinical:parsedIndicationReference ;
+    sh:nodeKind sh:IRI ;
+    sh:severity sh:Warning ;
+    sh:message "clinical:parsedIndicationReference should reference the matched reason record (a Condition or Observation) by IRI"@en ;
+    sh:name "Parsed Indication Reference Edge"@en .
+
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.12 (2026-07-20)
+# - Added ParsedIndicationReferenceEdgeShape for the new
+#   clinical:parsedIndicationReference subproperty. Warning-only and
+#   nodeKind-only, matching IndicationReferenceEdgeShape: the target class is
+#   deliberately NOT constrained, both because FHIR permits a Condition or an
+#   Observation as the reason and because cascade-cli validates each per-type
+#   pod file independently, so a cross-file sh:class check produces false
+#   positives (the v1.11 rationale, root 4.6a).
 #
 # Version 1.11 (2026-07-16)
 # - Removed the sh:class constraint from HasEncounterEdgeShape (clinical:Encounter)

--- a/ontologies/clinical/v1/clinical.ttl
+++ b/ontologies/clinical/v1/clinical.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-07-16"^^xsd:date ;
-    owl:versionInfo "1.11" ;
+    dct:modified "2026-07-20"^^xsd:date ;
+    owl:versionInfo "1.12" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -1301,6 +1301,27 @@ clinical:isActive a owl:DatatypeProperty ;
 # Changelog
 # ============================================================================
 #
+# Version 1.12 (2026-07-20)
+# - Added clinical:parsedIndicationReference ObjectProperty, a
+#   rdfs:subPropertyOf clinical:indicationReference. Records an indication edge
+#   the importer DERIVED by parsing a coded/free-text reason on the record
+#   (FHIR reasonCode, or a clinical:indication / clinical:reasonForUse literal)
+#   and matching it to a condition record in the same pod, as distinct from
+#   clinical:indicationReference proper, which restates an explicit
+#   reasonReference the source carried. Modeled as a subproperty so traversal
+#   over the superproperty returns both families while the predicate remains
+#   the machine-readable basis label; no reification and no RDF-star, keeping
+#   the edge a plain triple every existing consumer can already read.
+#   Motivation (M1 literal-lifting census, 2026-07-20): a real Apple Health
+#   provider export carried 0 reasonReference but 50 reasonCode instances on
+#   medication/procedure records, 25 of which resolve unambiguously to a
+#   condition record by exact coding identity. Those relations are dropped
+#   entirely today. Matching is code-first with a normalized-name fallback and
+#   unambiguous-only; ambiguous/unmatched are counted, never guessed.
+#   Deliberately NOT modeled with a confidence score: this is a deterministic
+#   parse of what the record says, not structural/temporal inference (which
+#   stays out of the pod and is computed at query time).
+#
 # Version 1.11 (2026-07-16)
 # - Widened clinical:indicationReference: dropped the restrictive
 #   rdfs:domain clinical:Medication in favor of the broad-domain comment +
@@ -1686,3 +1707,9 @@ clinical:linkedCondition a owl:ObjectProperty ;
     rdfs:comment "Links a condition to a related condition by IRI (e.g. a complication to its root condition). The traversable RDF replacement for the deprecated clinical:linkedConditionIds literal. FHIR R4 core has no first-class condition-to-condition reference; the closest precedents are the condition-dueTo and condition-occurredFollowing extensions (http://hl7.org/fhir/StructureDefinition/condition-dueTo). This property keeps the generic linked semantics of its predecessor; a more specific relation can be added later if a use case needs it."@en ;
     rdfs:domain clinical:Condition ;
     rdfs:range clinical:Condition .
+
+clinical:parsedIndicationReference a owl:ObjectProperty ;
+    rdfs:label "Parsed Indication Reference"@en ;
+    rdfs:comment "An indication edge the importer DERIVED by parsing a coded or free-text reason the record carries (FHIR reasonCode, or a clinical:indication / clinical:reasonForUse literal) and matching it to a condition record in the same pod. It is a subproperty of clinical:indicationReference, so one traversal over the superproperty returns both stated and parsed indications, while the predicate itself remains the machine-readable basis: clinical:indicationReference proper restates an explicit reference the SOURCE carried (FHIR reasonReference), whereas this property records a match the importer computed. Consumers must present the two differently (e.g. 'Indication' vs 'Indication (from record text)') because a parsed match is only as good as the code or wording it matched on. Matching is code-first (exact coding-system + code identity against the condition's own code) with a normalized-name fallback, and an edge is written only when exactly one candidate matches; ambiguous and unmatched reasons are counted in the import report, never guessed. This property carries no confidence score: it is a deterministic parse of what the record already says, NOT an inference from structure, timing, or co-occurrence, which remain out of scope for the importer and are computed at query time instead."@en ;
+    rdfs:subPropertyOf clinical:indicationReference ;
+    rdfs:range rdfs:Resource .


### PR DESCRIPTION
## Ratification table (the one modeling decision)

**The question:** how should an indication edge the importer PARSED (from a
record's coded or free-text reason) be machine-distinguishable from one the
source STATED (FHIR `reasonReference`), without breaking traversal?

| Option | Mechanism | Traversal | Verdict |
|---|---|---|---|
| **A. Subproperty (SHIPPED)** | `clinical:parsedIndicationReference rdfs:subPropertyOf clinical:indicationReference` | One query on the superproperty returns both families; the predicate itself is the basis | **Recommended.** Plain triples, zero new machinery, every existing consumer reads it today |
| B. Basis literal on the record | Keep one predicate, add e.g. `clinical:indicationBasis "parsed"` | Same | Rejected: the basis is not attached to the specific EDGE, so a record with one stated and one parsed indication becomes ambiguous |
| C. Reification / RDF-star | Statement-about-statement | Needs new query support | Rejected: heavyweight, and neither `n3` traversal nor the SHACL validator handles it today |
| D. Separate unrelated property | `clinical:derivedIndication`, no subproperty link | Breaks: consumers must know both | Rejected: silently splits the "what is this drug for?" query |

**Naming:** `parsedIndicationReference` (kickoff working name kept). "Parsed"
is accurate and narrow: it is a deterministic restatement of what the record
already says, NOT an inference from structure, timing, or co-occurrence. Those
stay out of the pod entirely and are computed at query time (ratified GM-Q2), so
the vocabulary should not invite them into this term later.

**Deliberately NOT included:** a confidence score. A parsed match is either an
exact coding identity or an exact normalized-name equality, and an edge is only
written when exactly one candidate matches. Ambiguity is reported to the import
log, never encoded as a low-confidence edge. If GM-Q3's oracle later wants
scored edges, that is the M4 inference family's problem, not this one.

**SHACL:** `ParsedIndicationReferenceEdgeShape` is warning-only and
`sh:nodeKind sh:IRI` only, with **no `sh:class`**, matching
`IndicationReferenceEdgeShape`. Two reasons: FHIR permits a Condition or an
Observation as the reason, and cascade-cli validates each per-type pod file
independently, so a cross-file `sh:class` check produces false positives on
every well-formed edge (the v1.11 rationale; root 4.6a tracks the pod-wide
validator that could enforce it properly).

## Why this term exists (the evidence)

M1's Phase 0 census, over three corpora:

| Corpus | `reasonReference` (stated) | `reasonCode` (parseable) | Indication edges without this term |
|---|---|---|---|
| Synthea `Grant908_Haley279` | 19 | 9 | 19 |
| Epic "Lucy" C-CDA export | 0 | 0 | 0 |
| Real provider export via Apple Health | **0** | **50** | **0** |

For the Apple Health population, `reasonReference` does not exist, so the shipped
R3 stated-edge path yields nothing and "what is this drug for?" has no graph
answer at all. Of its 50 `reasonCode` instances, 25 resolve unambiguously to a
condition record by exact coding identity (normalized-name matching resolved 0,
which is why the importer matches code-first). The importer previously discarded
`reasonCode` outright.

## What changed

- `clinical.ttl` — new `clinical:parsedIndicationReference` ObjectProperty
  (`rdfs:subPropertyOf clinical:indicationReference`, `rdfs:range rdfs:Resource`),
  changelog block, `owl:versionInfo` 1.12, `dct:modified` 2026-07-20.
- `clinical.shapes.ttl` — `ParsedIndicationReferenceEdgeShape` + changelog.
- `contexts/v1/clinical.jsonld` — term mapping (`"@type": "@id"`).
- `VOCAB_VERSIONS` — `clinical=1.12`.
- `PENDING_DOWNSTREAM_SYNC.md` — ledger row (cascade-cli syncs now; docs site,
  conformance, both SDKs, and the agent batch with the v1.10/v1.11 rows).

Additive only: no existing term changed, so pods predating this validate
unchanged.

## Consumer note

`clinical:parsedIndicationReference` must be presented **differently** from a
stated indication wherever a user sees it (Workbench uses "Indication (from
record text)" vs "Indication"). A parsed match is only as good as the code or
wording it matched on. Tracked as workbench `[M1B-PARSED-INDICATION-LABEL]`;
until it lands, the app's edge-ranking allowlist omits the predicate, so M1
cannot touch the verdict path.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
