### PR TITLE
docs(schema): define and shape the five clinical record classes (health v2.5, clinical v1.13, core v3.4)

### DIFF
--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -280,6 +280,77 @@ record by exact coding identity. Those relations are dropped entirely today.
 
 ---
 
+## Pending batch — health v2.5 / clinical v1.13 / core v3.4 (authored 2026-08-03)
+
+Three released-vocab changes authored together because they are one change:
+defining record classes in `health` is what makes the `clinical` duplicates
+deprecable, and the pod manifest in `core` counts the same records. Tags
+`vocab/health-v2.5`, `vocab/clinical-v1.13`, `vocab/core-v3.4`. **Additive
+vocabulary plus shapes only — no serializer, converter or emitter changed in
+any repo.**
+
+**What was authored:**
+
+- `health` 2.4 to 2.5 — 5 record classes (`LabResultRecord`, `ConditionRecord`,
+  `AllergyRecord`, `ImmunizationRecord`, `FamilyHistoryRecord`) that serializers
+  have emitted since schema 1.3 but the ontology never defined; the 40
+  properties they use; 6 wellness container classes as
+  `rdfs:subClassOf health:HealthProfile`; 4 sleep-quality named individuals; a
+  namespace-boundary note stating that `health:` vs `clinical:` is historical
+  and that provenance is carried only by `cascade:dataProvenance`.
+- `health.shapes.ttl` 1.1 to 1.2 — 8 new node shapes (the 5 record classes plus
+  `DailyVitalReading`, `DailyActivitySnapshot`, `DailySleepSnapshot`).
+  Constraint sets lifted from the corresponding `clinical:*` shapes and checked
+  against FHIR R4; `sh:Violation` on required fields.
+  `HealthProfileShape` now names the 6 wellness containers as explicit
+  additional `sh:targetClass` values.
+- `clinical` 1.12 to 1.13 — `owl:deprecated true` + `rdfs:seeAlso` on
+  `clinical:LabResult`, `Condition`, `Allergy`, `Immunization`. **Not removed:**
+  the pod export path is still their sole emitter. Also documents the intended
+  FHIR value sets on `clinical:status` and `clinical:interpretation` and records
+  why two of them are deliberately unenforced (constraining either is breaking
+  for existing pods). No shape changed.
+- `core` 3.3 to 3.4 — the pod export manifest vocabulary: 32 previously
+  undefined `cascade:` terms. `ExportManifest` as `rdfs:subClassOf dcat:Dataset`
+  (DCAT 3), `RecordSummary` as `rdfs:subClassOf void:Dataset` with counts as
+  `rdfs:subPropertyOf void:entities`, `InteractionScenario` kept novel.
+  `core.shapes.ttl` 1.0 to 1.1 adds shapes for all three.
+
+**Measured against the reference patient pod (19 files):** undefined `health:`
+terms 51 to 0, undefined `cascade:` terms 32 to 0, typed subjects matched by
+some shape 156 of 448 to 277 of 448. Validation stays 19 of 19 PASS with 0
+violations — the pod's data is conformant, what changed is that it is now
+actually checked.
+
+**Synced NOW (not batched):**
+
+- [x] `spec/` — authored (this repo); `VOCAB_VERSIONS` `health=2.5`,
+      `clinical=1.13`, `core=3.4`.
+- [ ] `cascade-cli` — `sync-shapes-from-spec.sh` (embedded `health.ttl`,
+      `health.shapes.ttl`, `clinical.ttl`, `core.ttl`, `core.shapes.ttl`) +
+      `VOCAB_VERSIONS`. Note: `src/shapes/health.ttl` has never been synced by
+      that script, which syncs full ontologies for `core clinical coverage`
+      only; fix the script in the same pass.
+
+**Batched (do NOT execute now; fold into the clinical v1.10/v1.11/v1.12 batch
+above — those repos are still at `clinical=1.9`):**
+
+- [ ] `cascadeprotocol.org` — HTML docs + `cascade-protocol-schemas.md`: the
+      five record classes are now defined and shaped, so the four "note on type
+      discrepancy" blocks in the serialization docs are stale. Retype the
+      reference pod's six wellness containers.
+- [ ] `conformance` — 26 existing fixtures (`lab-001..007`, `cond-001..007`,
+      `allergy-001..006`, `imm-001..003`, `fam-001..003`) become executable
+      against real constraints; add wellness fixtures for the 3 daily shapes.
+      Bump `VOCAB_VERSIONS`.
+- [ ] `sdk-typescript` / `sdk-python` — model files for the 5 record classes,
+      JSON-LD context terms, `VOCAB_VERSIONS`.
+- [ ] `cascade-agent` — query patterns for the record classes; `VOCAB_VERSIONS`.
+- [ ] `cascade-sdk-swift` — `VOCAB_VERSIONS` only. No serializer change: it is
+      already emitting the ratified names.
+
+---
+
 ## Open items
 
 ### 1. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -4,7 +4,7 @@
 # Format: {vocab}={major}.{minor}
 core=3.3
 health=2.5
-clinical=1.12
+clinical=1.13
 coverage=1.3
 checkup=3.2
 pots=1.4

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -3,7 +3,7 @@
 # as they implement support for each vocabulary version.
 # Format: {vocab}={major}.{minor}
 core=3.3
-health=2.4
+health=2.5
 clinical=1.12
 coverage=1.3
 checkup=3.2

--- a/VOCAB_VERSIONS
+++ b/VOCAB_VERSIONS
@@ -2,7 +2,7 @@
 # Maintained in spec/. Downstream repos copy this file and update it
 # as they implement support for each vocabulary version.
 # Format: {vocab}={major}.{minor}
-core=3.3
+core=3.4
 health=2.5
 clinical=1.13
 coverage=1.3

--- a/contexts/v1/core.jsonld
+++ b/contexts/v1/core.jsonld
@@ -12,6 +12,8 @@
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "foaf": "http://xmlns.com/foaf/0.1/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "void": "http://rdfs.org/ns/void#",
 
     "DataProvenance": "cascade:DataProvenance",
     "ConsumerGenerated": "cascade:ConsumerGenerated",
@@ -184,6 +186,46 @@
     "proxyRevokedAt": {
       "@id": "cascade:proxyRevokedAt",
       "@type": "xsd:dateTime"
-    }
+    },
+
+    "_comment_v3_4": "core v3.4 — pod export manifest (DCAT/VoID grounded) and reading-level terms",
+
+    "ExportManifest": "cascade:ExportManifest",
+    "RecordSummary": "cascade:RecordSummary",
+    "InteractionScenario": "cascade:InteractionScenario",
+
+    "patientProfileVersion": "cascade:patientProfileVersion",
+    "provenanceLayers": { "@id": "cascade:provenanceLayers", "@container": "@list", "@type": "@id" },
+    "clinicalSummary": { "@id": "cascade:clinicalSummary", "@type": "@id" },
+    "wellnessSummary": { "@id": "cascade:wellnessSummary", "@type": "@id" },
+    "deviceSources": { "@id": "cascade:deviceSources", "@container": "@list" },
+    "interactionScenarios": { "@id": "cascade:interactionScenarios", "@container": "@list" },
+
+    "domain": "cascade:domain",
+    "coreNotes": "cascade:notes",
+    "conditionCount": { "@id": "cascade:conditionCount", "@type": "xsd:integer" },
+    "medicationCount": { "@id": "cascade:medicationCount", "@type": "xsd:integer" },
+    "allergyCount": { "@id": "cascade:allergyCount", "@type": "xsd:integer" },
+    "labResultCount": { "@id": "cascade:labResultCount", "@type": "xsd:integer" },
+    "immunizationCount": { "@id": "cascade:immunizationCount", "@type": "xsd:integer" },
+    "coverageCount": { "@id": "cascade:coverageCount", "@type": "xsd:integer" },
+    "supplementCount": { "@id": "cascade:supplementCount", "@type": "xsd:integer" },
+    "vitalSignDays": { "@id": "cascade:vitalSignDays", "@type": "xsd:integer" },
+    "heartRateDays": { "@id": "cascade:heartRateDays", "@type": "xsd:integer" },
+    "bloodPressureDays": { "@id": "cascade:bloodPressureDays", "@type": "xsd:integer" },
+    "activityDays": { "@id": "cascade:activityDays", "@type": "xsd:integer" },
+    "sleepDays": { "@id": "cascade:sleepDays", "@type": "xsd:integer" },
+
+    "involvedResources": { "@id": "cascade:involvedResources", "@container": "@list", "@type": "@id" },
+    "severity": "cascade:severity",
+    "requiresCrossProvenance": { "@id": "cascade:requiresCrossProvenance", "@type": "xsd:boolean" },
+
+    "sourceType": "cascade:sourceType",
+    "dataTypes": "cascade:dataTypes",
+    "version": "cascade:version",
+
+    "date": { "@id": "cascade:date", "@type": "xsd:dateTime" },
+    "sampleCount": { "@id": "cascade:sampleCount", "@type": "xsd:integer" },
+    "coreLoincCode": { "@id": "cascade:loincCode", "@type": "@id" }
   }
 }

--- a/contexts/v1/health.jsonld
+++ b/contexts/v1/health.jsonld
@@ -291,6 +291,69 @@
     "healthLoincCode": "health:loincCode",
     "healthUnit": "health:unit",
     "healthUcumCode": "health:ucumCode",
-    "trendPolarity": "health:trendPolarity"
+    "trendPolarity": "health:trendPolarity",
+
+    "_comment_v2_5": "health v2.5 — clinical record classes, wellness containers, daily snapshot properties",
+
+    "LabResultRecord": "health:LabResultRecord",
+    "ConditionRecord": "health:ConditionRecord",
+    "AllergyRecord": "health:AllergyRecord",
+    "ImmunizationRecord": "health:ImmunizationRecord",
+    "FamilyHistoryRecord": "health:FamilyHistoryRecord",
+    "SocialHistoryRecord": "health:SocialHistoryRecord",
+    "ActivityData": "health:ActivityData",
+    "SleepData": "health:SleepData",
+    "HeartRateData": "health:HeartRateData",
+    "BloodPressureData": "health:BloodPressureData",
+    "HRVData": "health:HRVData",
+    "BodyMeasurements": "health:BodyMeasurements",
+    "SleepQuality": "health:SleepQuality",
+
+    "notes": "health:notes",
+    "sourceRecordId": "health:sourceRecordId",
+    "status": "health:status",
+    "onsetDate": { "@id": "health:onsetDate", "@type": "xsd:dateTime" },
+    "conditionName": "health:conditionName",
+
+    "testName": "health:testName",
+    "resultValue": "health:resultValue",
+    "resultUnit": "health:resultUnit",
+    "interpretation": "health:interpretation",
+    "performedDate": { "@id": "health:performedDate", "@type": "xsd:dateTime" },
+    "reportedDate": { "@id": "health:reportedDate", "@type": "xsd:dateTime" },
+    "testCode": { "@id": "health:testCode", "@type": "@id" },
+    "labCategory": "health:labCategory",
+    "referenceRange": "health:referenceRange",
+    "specimenType": "health:specimenType",
+    "orderingProvider": "health:orderingProvider",
+    "performingLab": "health:performingLab",
+
+    "icd10Code": { "@id": "health:icd10Code", "@type": "@id" },
+    "conditionClass": "health:conditionClass",
+    "monitoredVitalSigns": { "@id": "health:monitoredVitalSigns", "@container": "@list" },
+
+    "allergen": "health:allergen",
+    "allergyCategory": "health:allergyCategory",
+    "reaction": "health:reaction",
+    "allergySeverity": "health:allergySeverity",
+
+    "vaccineName": "health:vaccineName",
+    "administrationDate": { "@id": "health:administrationDate", "@type": "xsd:dateTime" },
+    "vaccineCode": "health:vaccineCode",
+    "manufacturer": "health:manufacturer",
+    "lotNumber": "health:lotNumber",
+    "doseQuantity": "health:doseQuantity",
+    "route": "health:route",
+    "site": "health:site",
+    "administeringProvider": "health:administeringProvider",
+    "administeringLocation": "health:administeringLocation",
+
+    "onsetAge": { "@id": "health:onsetAge", "@type": "xsd:integer" },
+
+    "steps": { "@id": "health:steps", "@type": "xsd:integer" },
+    "activeEnergyKcal": { "@id": "health:activeEnergyKcal", "@type": "xsd:decimal" },
+    "exerciseMinutes": { "@id": "health:exerciseMinutes", "@type": "xsd:integer" },
+    "standHours": { "@id": "health:standHours", "@type": "xsd:integer" },
+    "durationHours": { "@id": "health:durationHours", "@type": "xsd:decimal" }
   }
 }

--- a/ontologies/clinical/v1/clinical.shapes.ttl
+++ b/ontologies/clinical/v1/clinical.shapes.ttl
@@ -245,6 +245,36 @@ clinical:DischargeSummaryShape a sh:NodeShape ;
     ] .
 
 # ============================================================================
+# Shape: Consultation Note (v1.13)
+# ============================================================================
+#
+# clinical:ConsultationNote is rdfs:subClassOf clinical:ClinicalDocument, and
+# its five sibling subclasses (ProgressNote, DischargeSummary,
+# LaboratoryReport, ImagingReport, VisitSummary) each carry an explicit
+# sh:targetClass. This one did not, and a subclass axiom alone does not
+# inherit a shape: SHACL resolves sh:targetClass over SHACL-instances in the
+# DATA graph, so an axiom that lives only in clinical.ttl does not expand the
+# target set. Consultation notes were therefore validating vacuously while
+# every other document type was checked, and nothing reported the difference.
+
+clinical:ConsultationNoteShape a sh:NodeShape ;
+    sh:targetClass clinical:ConsultationNote ;
+    rdfs:label "Consultation Note Shape"@en ;
+    rdfs:comment "Additional constraints for specialist consultation notes"@en ;
+
+    # Inherits ClinicalDocument constraints
+    sh:node clinical:ClinicalDocumentShape ;
+
+    # Consultation notes should record when the consultation happened
+    sh:property [
+        sh:path clinical:encounterDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Encounter Date"@en ;
+        sh:message "Consultation note must not carry more than one encounter date"@en
+    ] .
+
+# ============================================================================
 # Shape: Laboratory Report
 # ============================================================================
 

--- a/ontologies/clinical/v1/clinical.ttl
+++ b/ontologies/clinical/v1/clinical.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for clinical documents, narratives, and structured notes imported from EHR systems via Apple HealthKit"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-26"^^xsd:date ;
-    dct:modified "2026-07-20"^^xsd:date ;
-    owl:versionInfo "1.12" ;
+    dct:modified "2026-08-03"^^xsd:date ;
+    owl:versionInfo "1.13" ;
     rdfs:comment "Domain-specific vocabulary for clinical documentation and structured records imported from patient portals (MyChart, Epic, etc.). Contains EHR-verified clinical data."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/clinical/v1.0/> .
 
@@ -101,27 +101,39 @@ clinical:Medication a owl:Class ;
 
 clinical:Allergy a owl:Class ;
     rdfs:label "Allergy"@en ;
-    rdfs:comment "Allergy or intolerance record from EHR AllergyIntolerance resource"@en ;
+    rdfs:comment "Allergy or intolerance record from EHR AllergyIntolerance resource. DEPRECATED in clinical v1.13: use health:AllergyRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:AllergyIntolerance ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#AllergyRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:AllergyRecord" .
 
 clinical:LabResult a owl:Class ;
     rdfs:label "Lab Result"@en ;
-    rdfs:comment "Laboratory test result from EHR Observation resource"@en ;
+    rdfs:comment "Laboratory test result from EHR Observation resource. DEPRECATED in clinical v1.13: use health:LabResultRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:Observation ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#LabResultRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:LabResultRecord" .
 
 clinical:Condition a owl:Class ;
     rdfs:label "Condition"@en ;
-    rdfs:comment "Medical condition or diagnosis from EHR Condition resource"@en ;
+    rdfs:comment "Medical condition or diagnosis from EHR Condition resource. DEPRECATED in clinical v1.13: use health:ConditionRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:Condition ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#ConditionRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:ConditionRecord" .
 
 clinical:Immunization a owl:Class ;
     rdfs:label "Immunization"@en ;
-    rdfs:comment "Vaccination record from EHR Immunization resource"@en ;
+    rdfs:comment "Vaccination record from EHR Immunization resource. DEPRECATED in clinical v1.13: use health:ImmunizationRecord, which is the type every import path already emits. Retained, not removed: the pod export path is still the sole emitter of this class and existing pods contain it. Readers must continue to accept both."@en ;
     rdfs:subClassOf fhir:Immunization ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    owl:deprecated true ;
+    rdfs:seeAlso <https://ns.cascadeprotocol.org/health/v1#ImmunizationRecord> ;
+    owl:versionInfo "Deprecated in clinical v1.13; superseded by health:ImmunizationRecord" .
 
 clinical:Procedure a owl:Class ;
     rdfs:label "Procedure"@en ;
@@ -496,7 +508,20 @@ clinical:recordDate a owl:DatatypeProperty ;
 
 clinical:status a owl:DatatypeProperty ;
     rdfs:label "Status"@en ;
-    rdfs:comment "FHIR status of the record (active, completed, etc.)"@en ;
+    rdfs:comment """Lifecycle status of the record. Permitted values depend on the record class and are constrained per-shape, not on this property.
+
+INTENDED VALUE SETS (FHIR R4). Recorded here in v1.13 because they are only partly enforced, and the gap should be visible in the vocabulary rather than only in the shapes:
+
+  clinical:Immunization   ImmunizationStatusCodes    completed | entered-in-error | not-done
+                          -- ENFORCED by clinical:ImmunizationShape
+  clinical:Procedure      EventStatus
+                          -- ENFORCED by clinical:ProcedureShape
+  clinical:Medication     MedicationRequest.status   active | on-hold | cancelled | completed |
+                                                     entered-in-error | stopped | draft | unknown
+                          -- NOT ENFORCED by clinical:MedicationShape
+
+The omission on medications is deliberate as of v1.13, not an oversight. Emitted data uses at least one value outside the FHIR set ("discontinued"; the FHIR equivalents are "stopped" and "ended"), so adding sh:in would be a BREAKING change for existing pods, not a clarification: records that validate today would start failing without any emitter having been corrected first. The ordered fix is to map emitters onto the FHIR value set, then add the constraint in a release explicitly flagged as tightening."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-medicationrequest-status.html> ;
     rdfs:range xsd:string .
 
 clinical:loincCode a owl:DatatypeProperty ;
@@ -702,7 +727,12 @@ clinical:referenceRange a owl:DatatypeProperty ;
 
 clinical:interpretation a owl:DatatypeProperty ;
     rdfs:label "Interpretation"@en ;
-    rdfs:comment "Interpretation flag (normal, high, low, abnormal)"@en ;
+    rdfs:comment """Categorical reading of an observation against its reference range.
+
+clinical:LabResultShape constrains this property with sh:in to normal | high | low | abnormal | critical (and capitalized forms). clinical:VitalSignShape deliberately does NOT, and as of v1.13 the inconsistency is intentional rather than an oversight: emitted vital-sign data uses "elevated", which is outside the lab set, so applying the lab constraint to vital signs would be a BREAKING change for existing pods rather than a clarification.
+
+Note also that neither set is the FHIR set. FHIR R4 Observation.interpretation binds to v3-ObservationInterpretation, whose codes are symbolic (N, H, L, A, HH, LL, AA), not English words. Both Cascade sets are local vocabulary. Reconciling the two spellings and then aligning them onto the FHIR codes is the ordered fix; doing either half on its own breaks readers."""@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-observation-interpretation.html> ;
     rdfs:range xsd:string .
 
 clinical:specimenType a owl:DatatypeProperty ;
@@ -1300,6 +1330,33 @@ clinical:isActive a owl:DatatypeProperty ;
 # ============================================================================
 # Changelog
 # ============================================================================
+#
+# Version 1.13 (2026-08-03)
+# - Deprecated 4 classes: clinical:LabResult, clinical:Condition,
+#   clinical:Allergy, clinical:Immunization. Each carries owl:deprecated true
+#   and rdfs:seeAlso pointing at its health: equivalent, which is the type
+#   every import path already emits and which health v2.5 now defines and
+#   shapes. NOT removed: the pod export path remains the sole emitter of these
+#   four classes, and existing pods contain them. Readers must accept both
+#   spellings; writers should prefer the health: forms. No emitter changed in
+#   this release.
+# - Documented the intended FHIR R4 value sets on clinical:status and
+#   clinical:interpretation, and recorded WHY two of them are not enforced.
+#   clinical:MedicationShape has no sh:in on status and clinical:VitalSignShape
+#   has none on interpretation, while the sibling shapes do. Emitted data uses
+#   "discontinued" for medication status and "elevated" for vital-sign
+#   interpretation, neither of which is in the corresponding constrained set,
+#   so adding the constraints would be breaking for existing pods rather than
+#   clarifying. The gap is now stated in the vocabulary instead of being
+#   visible only as an absence in the shapes.
+# - Added clinical:ConsultationNoteShape. clinical:ConsultationNote is one of
+#   six rdfs:subClassOf clinical:ClinicalDocument; the other five each carry an
+#   explicit sh:targetClass and this one did not. A subclass axiom does not
+#   inherit a shape (SHACL resolves sh:targetClass over SHACL-instances in the
+#   DATA graph, so an axiom in this file does not expand the target set), so
+#   consultation notes were validating vacuously while every sibling document
+#   type was checked. Consequence: a consultation note missing importedAt,
+#   sourceEHR or fhirResourceId passed before and fails now.
 #
 # Version 1.12 (2026-07-20)
 # - Added clinical:parsedIndicationReference ObjectProperty, a

--- a/ontologies/core/v1/core.shapes.ttl
+++ b/ontologies/core/v1/core.shapes.ttl
@@ -2,13 +2,16 @@
 @prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 
 # ============================================================================
 # Cascade Protocol -- Core Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.0 (Phase 4, 2026-02-18)
+# Version: 1.1 (2026-08-03)
 # Validates: cascade:PatientProfile, cascade:Address, cascade:EmergencyContact,
-#            cascade:PharmacyInfo, cascade:AdvanceDirectives
+#            cascade:PharmacyInfo, cascade:AdvanceDirectives, cascade:ProxyAgent,
+#            cascade:ExportManifest, cascade:RecordSummary,
+#            cascade:InteractionScenario
 #
 # Severity levels:
 #   sh:Violation -- Must fix (blocks operations)
@@ -656,3 +659,168 @@ cascade:ProxyAgentShape a sh:NodeShape ;
                   sh:message "A ProxyAgent must declare the patient it acts for (cascade:actsForPatient)." ] ;
     sh:property [ sh:path cascade:proxyRelationship ; sh:minCount 1 ; sh:datatype xsd:string ] ;
     sh:property [ sh:path cascade:proxyGrantedAt ; sh:minCount 1 ; sh:datatype xsd:dateTime ] .
+
+# ============================================================================
+# Pod Export Manifest Shapes (v1.1 -- core v3.4)
+# ============================================================================
+#
+# The manifest is the first thing a consuming agent reads and the thing it
+# trusts to decide whether an export is complete. Until core v3.4 none of its
+# classes was defined, so nothing targeted them and validating a manifest
+# checked nothing at all.
+
+cascade:ExportManifestShape a sh:NodeShape ;
+    sh:targetClass cascade:ExportManifest ;
+    rdfs:label "Export Manifest Shape"@en ;
+    rdfs:comment "Validation constraints for a pod export manifest. cascade:ExportManifest is a dcat:Dataset, so the DCAT-standard descriptive terms are the required ones."@en ;
+
+    # REQUIRED: a title. An untitled dataset cannot be presented to a user.
+    sh:property [
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Title"@en ;
+        sh:message "Export manifest must carry exactly one non-empty dct:title"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: creation timestamp. Without it a consumer cannot tell whether
+    # the export is current, which is the manifest's main job.
+    sh:property [
+        sh:path dct:created ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Created"@en ;
+        sh:message "Export manifest must carry exactly one dct:created timestamp"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: schema version, so a consumer can refuse an export it cannot read
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Export manifest must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:patientProfileVersion ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Patient Profile Version"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:clinicalSummary ;
+        sh:maxCount 1 ;
+        sh:name "Clinical Summary"@en ;
+        sh:message "Export manifest must not carry more than one clinical summary"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:wellnessSummary ;
+        sh:maxCount 1 ;
+        sh:name "Wellness Summary"@en ;
+        sh:message "Export manifest must not carry more than one wellness summary"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path dct:description ;
+        sh:maxCount 1 ;
+        sh:name "Description"@en ;
+        sh:severity sh:Violation
+    ] .
+
+cascade:RecordSummaryShape a sh:NodeShape ;
+    sh:targetClass cascade:RecordSummary ;
+    rdfs:label "Record Summary Shape"@en ;
+    rdfs:comment "Validation constraints for per-domain record counts. Every count must be a single non-negative integer: a negative or repeated count silently corrupts any completeness check built on it."@en ;
+
+    sh:property [
+        sh:path cascade:domain ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Domain"@en ;
+        sh:message "Record summary must name exactly one domain"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [ sh:path cascade:conditionCount ;     sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Condition Count"@en ;      sh:message "conditionCount must be a single non-negative integer"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:medicationCount ;    sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Medication Count"@en ;     sh:message "medicationCount must be a single non-negative integer"@en ;     sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:allergyCount ;       sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Allergy Count"@en ;        sh:message "allergyCount must be a single non-negative integer"@en ;        sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:labResultCount ;     sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Lab Result Count"@en ;     sh:message "labResultCount must be a single non-negative integer"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:immunizationCount ;  sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Immunization Count"@en ;   sh:message "immunizationCount must be a single non-negative integer"@en ;   sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:coverageCount ;      sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Coverage Count"@en ;       sh:message "coverageCount must be a single non-negative integer"@en ;       sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:supplementCount ;    sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:name "Supplement Count"@en ;     sh:message "supplementCount must be a single non-negative integer"@en ;     sh:severity sh:Violation ] ;
+
+    # Day counts are bounded above as well: a "days covered" figure larger than
+    # a decade of daily readings is a unit error, not a long history.
+    sh:property [ sh:path cascade:vitalSignDays ;      sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Vital Sign Days"@en ;      sh:message "vitalSignDays must be a single integer between 0 and 36500"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:heartRateDays ;      sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Heart Rate Days"@en ;      sh:message "heartRateDays must be a single integer between 0 and 36500"@en ;      sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:bloodPressureDays ;  sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Blood Pressure Days"@en ;  sh:message "bloodPressureDays must be a single integer between 0 and 36500"@en ;  sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:activityDays ;       sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Activity Days"@en ;       sh:message "activityDays must be a single integer between 0 and 36500"@en ;       sh:severity sh:Violation ] ;
+    sh:property [ sh:path cascade:sleepDays ;          sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minInclusive 0 ; sh:maxInclusive 36500 ; sh:name "Sleep Days"@en ;          sh:message "sleepDays must be a single integer between 0 and 36500"@en ;          sh:severity sh:Violation ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:severity sh:Violation
+    ] .
+
+cascade:InteractionScenarioShape a sh:NodeShape ;
+    sh:targetClass cascade:InteractionScenario ;
+    rdfs:label "Interaction Scenario Shape"@en ;
+    rdfs:comment "Validation constraints for a flagged cross-provenance interaction. A scenario that names no resources is not actionable, so involvedResources is required."@en ;
+
+    sh:property [
+        sh:path dct:title ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Title"@en ;
+        sh:message "Interaction scenario must carry exactly one non-empty dct:title"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: the resources to correlate. Without them the scenario states a
+    # risk exists but gives a consumer nothing to check it against.
+    sh:property [
+        sh:path cascade:involvedResources ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Involved Resources"@en ;
+        sh:message "Interaction scenario must name exactly one list of involved resources"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:severity ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("low" "moderate" "high" "critical") ;
+        sh:name "Severity"@en ;
+        sh:message "Interaction scenario severity must be low, moderate, high or critical"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:requiresCrossProvenance ;
+        sh:datatype xsd:boolean ;
+        sh:maxCount 1 ;
+        sh:name "Requires Cross-Provenance"@en ;
+        sh:message "requiresCrossProvenance must be a single boolean"@en ;
+        sh:severity sh:Violation
+    ] .

--- a/ontologies/core/v1/core.ttl
+++ b/ontologies/core/v1/core.ttl
@@ -7,6 +7,8 @@
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix void: <http://rdfs.org/ns/void#> .
 
 # ============================================================================
 # Ontology Metadata
@@ -17,8 +19,8 @@
     dct:description "Core vocabulary for schema versioning, data provenance, identity management, and patient demographics across all Cascade Protocol applications"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-10-31"^^xsd:date ;
-    dct:modified "2026-06-16"^^xsd:date ;
-    owl:versionInfo "3.3" ;
+    dct:modified "2026-08-03"^^xsd:date ;
+    owl:versionInfo "3.4" ;
     rdfs:comment "This vocabulary defines cross-cutting concepts used by all Cascade Protocol health data applications: schema versioning, data provenance, patient demographics (PatientProfile), and supporting identity classes (Address, PharmacyInfo, AdvanceDirectives). Domain-specific vocabularies (e.g., pots:, ecg:, glucose:) import this core vocabulary."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/core/v1.0/> .
 
@@ -675,6 +677,30 @@ cascade:forSystem a owl:DatatypeProperty ;
 
 # ============================================================================
 # Changelog
+#
+# Version 3.4 (2026-08-03)
+# - Defined the pod export manifest vocabulary. 32 cascade: terms appearing in
+#   a conforming pod had no definition in this file at all; all 32 are now
+#   defined, so a manifest is describable rather than only parseable.
+# - cascade:ExportManifest is modelled as rdfs:subClassOf dcat:Dataset (DCAT 3,
+#   https://www.w3.org/TR/vocab-dcat-3/). A pod export is a dataset with a
+#   title, a description, a creation date and a publisher, which is what DCAT
+#   already standardises; inventing a parallel set of terms for it would have
+#   been novelty for its own sake.
+# - cascade:RecordSummary is modelled as rdfs:subClassOf void:Dataset (VoID,
+#   https://www.w3.org/TR/void/). Its ~15 per-domain count properties are
+#   declared rdfs:subPropertyOf void:entities and each is paired with the
+#   void:class it counts, so a VoID-aware consumer can read Cascade record
+#   counts with no Cascade-specific code. The Cascade-specific spellings are
+#   retained because they are what is emitted.
+# - cascade:InteractionScenario is kept as genuinely novel. It describes a
+#   cross-provenance clinical interaction that an agent must correlate across
+#   several resources; no ratified vocabulary covers it, so it is defined here
+#   rather than bent onto something that does not fit.
+# - Also defined the reading-level terms cascade:date, cascade:sampleCount and
+#   cascade:loincCode, which are emitted on every history-container entry and
+#   are constrained by the health v2.5 daily-snapshot shapes.
+#
 # ============================================================================
 # v3.2 (2026-05-06): Forward reference closure for advisory applier.
 #     Added cascade:appliedTriplesCount (DatatypeProperty, range xsd:nonNegativeInteger,
@@ -1138,3 +1164,286 @@ cascade:proxyRevokedAt a owl:DatatypeProperty ;
     rdfs:domain cascade:ProxyAgent ;
     rdfs:range xsd:dateTime ;
     owl:versionInfo "Added in core v3.3" .
+
+# ============================================================================
+# Pod Export Manifest (v3.4)
+# ============================================================================
+#
+# Every term in this section is emitted by a conforming pod export and none of
+# them was defined before v3.4. Defining them is additive: no serializer
+# changes and no manifest is rewritten.
+#
+# Modelling decisions, and the reasoning, because "we invented a term" is the
+# expensive default:
+#
+#   cascade:ExportManifest  -> rdfs:subClassOf dcat:Dataset
+#       A pod export is a published dataset with a title, description,
+#       creation date and publisher. DCAT 3 standardises exactly that and is a
+#       W3C Recommendation. https://www.w3.org/TR/vocab-dcat-3/
+#
+#   cascade:RecordSummary   -> rdfs:subClassOf void:Dataset
+#       A record summary is a statistical description of a subset of a
+#       dataset: how many instances of each class it contains. That is what
+#       VoID is for. Each count property below is declared
+#       rdfs:subPropertyOf void:entities and paired with the void:class it
+#       counts, so a VoID-aware consumer gets the counts for free.
+#       https://www.w3.org/TR/void/
+#
+#   cascade:InteractionScenario -> novel, deliberately
+#       A cross-provenance clinical interaction that an agent must detect by
+#       correlating resources of different provenance. No ratified vocabulary
+#       models this. It stays Cascade-specific rather than being forced onto
+#       something that does not fit.
+
+cascade:ExportManifest a owl:Class ;
+    rdfs:label "Export Manifest"@en ;
+    rdfs:comment "Provenance and completeness metadata for a complete pod export: when it was generated, which schema versions it uses, how many records of each kind it contains, and which provenance layers are represented. Consumers should read this before processing individual resources."@en ;
+    rdfs:subClassOf dcat:Dataset ;
+    rdfs:subClassOf prov:Entity ;
+    rdfs:seeAlso <https://www.w3.org/TR/vocab-dcat-3/> ;
+    owl:versionInfo "Added in core v3.4; emitted since schema 1.3" .
+
+cascade:RecordSummary a owl:Class ;
+    rdfs:label "Record Summary"@en ;
+    rdfs:comment "Per-domain record counts for one partition of a pod export. Modelled on void:Dataset because it is a statistical description of a dataset subset; each count property is a subproperty of void:entities scoped to a particular void:class."@en ;
+    rdfs:subClassOf void:Dataset ;
+    rdfs:seeAlso <https://www.w3.org/TR/void/> ;
+    owl:versionInfo "Added in core v3.4; emitted since schema 1.3" .
+
+cascade:InteractionScenario a owl:Class ;
+    rdfs:label "Interaction Scenario"@en ;
+    rdfs:comment "A clinically significant interaction that can only be detected by correlating resources of differing provenance, for example an EHR-prescribed drug against a self-reported supplement against a lab value. Cascade-specific: no ratified vocabulary models cross-provenance correlation as a first-class thing."@en ;
+    rdfs:subClassOf prov:Entity ;
+    owl:versionInfo "Added in core v3.4; emitted since schema 1.3" .
+
+# --- Manifest structure -----------------------------------------------------
+
+cascade:patientProfileVersion a owl:DatatypeProperty ;
+    rdfs:label "Patient Profile Version"@en ;
+    rdfs:comment "Version of the patient profile structure used in this export, independent of cascade:schemaVersion."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:provenanceLayers a owl:ObjectProperty ;
+    rdfs:label "Provenance Layers"@en ;
+    rdfs:comment "Ordered list of the cascade:DataProvenance values represented anywhere in this export. Lets a consumer tell, before reading any resource, whether the export contains device data, EHR data, self-reported data, or a mixture."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:clinicalSummary a owl:ObjectProperty ;
+    rdfs:label "Clinical Summary"@en ;
+    rdfs:comment "Record counts for the clinical partition of this export."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range cascade:RecordSummary ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:wellnessSummary a owl:ObjectProperty ;
+    rdfs:label "Wellness Summary"@en ;
+    rdfs:comment "Record counts for the wellness partition of this export."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range cascade:RecordSummary ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:deviceSources a owl:ObjectProperty ;
+    rdfs:label "Device Sources"@en ;
+    rdfs:comment "Ordered list of the devices that contributed data to this export, each a prov:Agent."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:interactionScenarios a owl:ObjectProperty ;
+    rdfs:label "Interaction Scenarios"@en ;
+    rdfs:comment "Ordered list of cascade:InteractionScenario entries flagged in this export."@en ;
+    rdfs:domain cascade:ExportManifest ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+# --- Record summary ---------------------------------------------------------
+
+cascade:domain a owl:DatatypeProperty ;
+    rdfs:label "Domain"@en ;
+    rdfs:comment "Which partition of the export this summary describes, for example 'clinical' or 'wellness'."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:notes a owl:DatatypeProperty ;
+    rdfs:label "Notes"@en ;
+    rdfs:comment "Free-text commentary on a summary or manifest section."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+# Counts. Each is a subproperty of void:entities paired with the void:class it
+# counts, so a VoID-aware consumer reads these without Cascade-specific code.
+
+cascade:conditionCount a owl:DatatypeProperty ;
+    rdfs:label "Condition Count"@en ;
+    rdfs:comment "Number of condition records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#ConditionRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:medicationCount a owl:DatatypeProperty ;
+    rdfs:label "Medication Count"@en ;
+    rdfs:comment "Number of medication records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/clinical/v1#Medication> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:allergyCount a owl:DatatypeProperty ;
+    rdfs:label "Allergy Count"@en ;
+    rdfs:comment "Number of allergy records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#AllergyRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:labResultCount a owl:DatatypeProperty ;
+    rdfs:label "Lab Result Count"@en ;
+    rdfs:comment "Number of laboratory result records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#LabResultRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:immunizationCount a owl:DatatypeProperty ;
+    rdfs:label "Immunization Count"@en ;
+    rdfs:comment "Number of immunization records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/health/v1#ImmunizationRecord> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:coverageCount a owl:DatatypeProperty ;
+    rdfs:label "Coverage Count"@en ;
+    rdfs:comment "Number of insurance coverage records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:supplementCount a owl:DatatypeProperty ;
+    rdfs:label "Supplement Count"@en ;
+    rdfs:comment "Number of supplement records in this partition."@en ;
+    rdfs:subPropertyOf void:entities ;
+    void:class <https://ns.cascadeprotocol.org/clinical/v1#Supplement> ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+# Day counts. These count DAYS COVERED, not entities, so they are deliberately
+# NOT subproperties of void:entities: a 30-day heart rate history may hold many
+# more readings than 30. Conflating the two would make the VoID reading wrong.
+
+cascade:vitalSignDays a owl:DatatypeProperty ;
+    rdfs:label "Vital Sign Days"@en ;
+    rdfs:comment "Number of distinct days covered by vital sign records in this partition. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:heartRateDays a owl:DatatypeProperty ;
+    rdfs:label "Heart Rate Days"@en ;
+    rdfs:comment "Number of distinct days covered by heart rate history. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:bloodPressureDays a owl:DatatypeProperty ;
+    rdfs:label "Blood Pressure Days"@en ;
+    rdfs:comment "Number of distinct days covered by blood pressure history. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:activityDays a owl:DatatypeProperty ;
+    rdfs:label "Activity Days"@en ;
+    rdfs:comment "Number of distinct days covered by activity history. A day count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:sleepDays a owl:DatatypeProperty ;
+    rdfs:label "Sleep Days"@en ;
+    rdfs:comment "Number of distinct nights covered by sleep history. A night count, not a record count."@en ;
+    rdfs:domain cascade:RecordSummary ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+# --- Interaction scenario ---------------------------------------------------
+
+cascade:involvedResources a owl:ObjectProperty ;
+    rdfs:label "Involved Resources"@en ;
+    rdfs:comment "Ordered list of the pod resources an agent must read together to detect this interaction."@en ;
+    rdfs:domain cascade:InteractionScenario ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:severity a owl:DatatypeProperty ;
+    rdfs:label "Severity"@en ;
+    rdfs:comment "Severity of the flagged interaction: low, moderate, high, or critical."@en ;
+    rdfs:domain cascade:InteractionScenario ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:requiresCrossProvenance a owl:DatatypeProperty ;
+    rdfs:label "Requires Cross-Provenance"@en ;
+    rdfs:comment "True when detecting this interaction requires correlating resources of different cascade:dataProvenance. The distinguishing property of this class: a single-source consumer cannot find it."@en ;
+    rdfs:domain cascade:InteractionScenario ;
+    rdfs:range xsd:boolean ;
+    owl:versionInfo "Added in core v3.4" .
+
+# --- Device sources ---------------------------------------------------------
+
+cascade:sourceType a owl:DatatypeProperty ;
+    rdfs:label "Source Type"@en ;
+    rdfs:comment "Mechanism a reading arrived through, for example healthKit, bluetoothDevice, manualEntry. Describes the transport, NOT the trustworthiness of the data; that is cascade:dataProvenance."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:dataTypes a owl:DatatypeProperty ;
+    rdfs:label "Data Types"@en ;
+    rdfs:comment "Comma-separated list of the data types a device contributed, for example 'heartRate, activity, sleep'."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:version a owl:DatatypeProperty ;
+    rdfs:label "Version"@en ;
+    rdfs:comment "Version string of a software agent or generator recorded in provenance."@en ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in core v3.4" .
+
+# ============================================================================
+# Reading-level Terms (v3.4)
+# ============================================================================
+#
+# Emitted on entries inside the health: history containers. Defined here rather
+# than in health: because they are not wellness-specific: any Cascade time
+# series entry carries a date and, where aggregated, a sample count.
+
+cascade:date a owl:DatatypeProperty ;
+    rdfs:label "Date"@en ;
+    rdfs:comment "Timestamp a reading or snapshot applies to. Note that health:date is a second, equivalent spelling emitted by a different serializer for the same purpose; readers of history containers must handle both."@en ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:sampleCount a owl:DatatypeProperty ;
+    rdfs:label "Sample Count"@en ;
+    rdfs:comment "Number of underlying samples aggregated into a single reading. A daily resting heart rate of 68 derived from 142 samples is a stronger observation than one derived from 2, and consumers should be able to tell the difference."@en ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in core v3.4" .
+
+cascade:loincCode a owl:ObjectProperty ;
+    rdfs:label "LOINC Code"@en ;
+    rdfs:comment "LOINC reference for an observation, as an IRI."@en ;
+    rdfs:seeAlso <http://loinc.org/> ;
+    owl:versionInfo "Added in core v3.4" .

--- a/ontologies/health/v1/health.shapes.ttl
+++ b/ontologies/health/v1/health.shapes.ttl
@@ -1,6 +1,7 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix health: <https://ns.cascadeprotocol.org/health/v1#> .
 @prefix cascade: <https://ns.cascadeprotocol.org/core/v1#> .
+@prefix clinical: <https://ns.cascadeprotocol.org/clinical/v1#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix fhir: <http://hl7.org/fhir/> .
@@ -8,17 +9,23 @@
 # ============================================================================
 # Cascade Protocol — Health & Wellness Vocabulary SHACL Validation Shapes
 # ============================================================================
-# Version: 1.0 (Phase 4, 2026-02-18)
+# Version: 1.2 (2026-08-03)
 # Validates: health:SelfReport, health:VO2MaxStatistics, health:HRVStatistics,
 #            health:BPStatistics, health:MetricTrend, health:ActivitySnapshot,
-#            health:SleepSnapshot, health:HealthProfile
+#            health:SleepSnapshot, health:HealthProfile,
+#            health:SocialHistoryRecord,
+#            health:LabResultRecord, health:ConditionRecord,
+#            health:AllergyRecord, health:ImmunizationRecord,
+#            health:FamilyHistoryRecord,
+#            health:DailyVitalReading, health:DailyActivitySnapshot,
+#            health:DailySleepSnapshot
 #
 # SEVERITY LEVELS:
 # - sh:Violation = Must fix (data invalid without) - e.g., missing required stats
 # - sh:Warning = Should address (important for completeness) - e.g., missing period
 # - sh:Info = Nice to have (suggested enrichment) - e.g., optional context fields
 #
-# Validates against: health.ttl v2.2 (2026-02-17)
+# Validates against: health.ttl v2.5 (2026-08-03)
 # ============================================================================
 
 # ============================================================================
@@ -568,6 +575,24 @@ health:SleepSnapshotShape a sh:NodeShape ;
 
 health:HealthProfileShape a sh:NodeShape ;
     sh:targetClass health:HealthProfile ;
+    # The six wellness containers are declared rdfs:subClassOf health:HealthProfile
+    # in health.ttl v2.5, and SHACL sh:targetClass is subclass-aware. But that
+    # aspect of targeting is evaluated against the DATA graph (SHACL 2.1.3.1
+    # defines "SHACL instance of" as rdf:type/rdfs:subClassOf* in the data
+    # graph), so it only fires for a validator that loads the vocabulary
+    # alongside the data. A validator that loads shapes only -- which is the
+    # common case, and is what the reference implementation does -- would see
+    # no target and check nothing, reproducing the vacuous PASS this release
+    # exists to remove.
+    #
+    # These six are therefore named explicitly as well. The subclass axioms
+    # remain the semantic statement; these make it effective today.
+    sh:targetClass health:ActivityData ;
+    sh:targetClass health:SleepData ;
+    sh:targetClass health:HeartRateData ;
+    sh:targetClass health:BloodPressureData ;
+    sh:targetClass health:HRVData ;
+    sh:targetClass health:BodyMeasurements ;
     rdfs:label "Health Profile Shape"@en ;
     rdfs:comment "Validation constraints for the top-level wellness profile aggregating vital signs, body measurements, activity, and sleep data from consumer devices. Stored at /wellness/ in the Cascade Pod."@en ;
 
@@ -704,6 +729,23 @@ health:SocialHistoryRecordShape a sh:NodeShape ;
 # Changelog
 # ============================================================================
 #
+# Version 1.2 (2026-08-03)
+# - Added 5 record shapes for the classes defined in health v2.5:
+#   LabResultRecordShape, ConditionRecordShape, AllergyRecordShape,
+#   ImmunizationRecordShape, FamilyHistoryRecordShape. Before this version
+#   these classes had no sh:targetClass anywhere, so validating a lab result,
+#   condition, allergy, immunization or family history record checked nothing
+#   and returned PASS.
+# - Added 3 shapes for classes that have existed since health v2.0 but were
+#   never targeted: DailyVitalReadingShape, DailyActivitySnapshotShape,
+#   DailySleepSnapshotShape.
+# - Constraint sets lifted from the corresponding clinical:* shapes and
+#   checked against FHIR R4. Where FHIR names a required value set the sh:in
+#   list is that value set verbatim.
+# - sh:Violation severity on all required fields.
+# - 29 conformance fixtures (7 lab, 7 condition, 6 allergy, 3 immunization,
+#   3 family history) become executable against real constraints.
+#
 # Version 1.1 (2026-03-27)
 # - Added SocialHistoryRecordShape for health:SocialHistoryRecord (health v2.4)
 #
@@ -722,3 +764,770 @@ health:SocialHistoryRecordShape a sh:NodeShape ;
 # - sh:in constraints match enumerated values from health.ttl ontology
 # - Range constraints (minInclusive/maxInclusive) reflect physiological bounds
 #
+
+# ============================================================================
+# Clinical Record Shapes (v1.2 — health v2.5)
+# ============================================================================
+#
+# Constraint sets are LIFTED from the corresponding clinical:* shapes in
+# clinical.shapes.ttl (AllergyShape :526, LabResultShape :607, ConditionShape
+# :685, ImmunizationShape :764) so that the two spellings of the same record
+# are held to the same standard, then checked against the FHIR R4 resource
+# definitions. Where FHIR names a required value set, the sh:in list below is
+# that value set verbatim:
+#
+#   health:allergyCategory   AllergyIntoleranceCategory     food | medication | environment | biologic
+#   health:allergySeverity   AllergyIntoleranceSeverity     mild | moderate | severe
+#   health:status (condition) ConditionClinicalStatusCodes  active | recurrence | relapse | inactive | remission | resolved
+#   health:status (immunization) ImmunizationStatusCodes    completed | entered-in-error | not-done
+#
+# health:status is deliberately constrained per-shape rather than on the
+# property: the permitted values differ by record class and a single global
+# sh:in would be wrong for both.
+#
+# Severity is sh:Violation on every required field. A Warning-severity
+# constraint on a required field reproduces the problem these shapes exist to
+# fix (a PASS that means nothing) with extra steps.
+#
+# CONSEQUENCE, STATED PLAINLY: before this release, validating a lab result,
+# condition, allergy, immunization or family-history record returned PASS
+# because no shape targeted it and nothing was checked. Those records are now
+# actually checked. A validation failure appearing after upgrade means the
+# validator improved, not that the data got worse.
+
+# ============================================================================
+# Shape 9: Lab Result Record
+# ============================================================================
+
+health:LabResultRecordShape a sh:NodeShape ;
+    sh:targetClass health:LabResultRecord ;
+    rdfs:label "Lab Result Record Shape"@en ;
+    rdfs:comment "Validation constraints for laboratory result records. Lifted from clinical:LabResultShape and checked against FHIR R4 Observation."@en ;
+
+    # REQUIRED: testName
+    sh:property [
+        sh:path health:testName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Test Name"@en ;
+        sh:message "Lab result must have exactly one non-empty testName"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED cardinality: resultValue is at most one.
+    # A single subject asserting two resultValues is the failure mode this
+    # constraint exists for: two same-day readings of the same analyte merged
+    # onto one record produce a subject with both values, which a consumer
+    # then reads as the single string "95, 310". Unconstrained, that passes.
+    sh:property [
+        sh:path health:resultValue ;
+        sh:maxCount 1 ;
+        sh:name "Result Value"@en ;
+        sh:message "Lab result must not carry more than one resultValue; two readings of the same analyte are two records"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:resultUnit ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Result Unit"@en ;
+        sh:message "Lab result must not carry more than one resultUnit"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:referenceRange ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Reference Range"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:interpretation ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("normal" "high" "low" "abnormal" "critical"
+               "Normal" "High" "Low" "Abnormal" "Critical") ;
+        sh:name "Interpretation"@en ;
+        sh:message "Interpretation must be one of normal, high, low, abnormal, critical"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:performedDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Performed Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:reportedDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Reported Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:testCode ;
+        sh:maxCount 1 ;
+        sh:name "Test Code (LOINC)"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:labCategory ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Lab Category"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:specimenType ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Specimen Type"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:orderingProvider ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Ordering Provider"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:performingLab ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Performing Laboratory"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: provenance
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Lab result must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: schemaVersion
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Lab result must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 10: Condition Record
+# ============================================================================
+
+health:ConditionRecordShape a sh:NodeShape ;
+    sh:targetClass health:ConditionRecord ;
+    rdfs:label "Condition Record Shape"@en ;
+    rdfs:comment "Validation constraints for condition and problem-list records. Lifted from clinical:ConditionShape and checked against FHIR R4 Condition."@en ;
+
+    # REQUIRED: conditionName
+    sh:property [
+        sh:path health:conditionName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Condition Name"@en ;
+        sh:message "Condition must have exactly one non-empty conditionName"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # status: FHIR R4 ConditionClinicalStatusCodes
+    sh:property [
+        sh:path health:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("active" "recurrence" "relapse" "inactive" "remission" "resolved") ;
+        sh:name "Clinical Status"@en ;
+        sh:message "Condition status must be one of the FHIR R4 ConditionClinicalStatusCodes: active, recurrence, relapse, inactive, remission, resolved"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:onsetDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Onset Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:icd10Code ;
+        sh:maxCount 1 ;
+        sh:name "ICD-10-CM Code"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:snomedCode ;
+        sh:maxCount 1 ;
+        sh:name "SNOMED CT Code"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:conditionClass ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Condition Class"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:monitoredVitalSigns ;
+        sh:maxCount 1 ;
+        sh:name "Monitored Vital Signs"@en ;
+        sh:message "Monitored vital signs must be a single rdf:List, not repeated"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Condition must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Condition must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 11: Allergy Record
+# ============================================================================
+
+health:AllergyRecordShape a sh:NodeShape ;
+    sh:targetClass health:AllergyRecord ;
+    rdfs:label "Allergy Record Shape"@en ;
+    rdfs:comment "Validation constraints for allergy and intolerance records. Lifted from clinical:AllergyShape and checked against FHIR R4 AllergyIntolerance."@en ;
+
+    # REQUIRED: allergen. An allergy record without an allergen carries no
+    # safety information at all, which is worse than having no record.
+    sh:property [
+        sh:path health:allergen ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Allergen"@en ;
+        sh:message "Allergy must specify exactly one non-empty allergen"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:reaction ;
+        sh:datatype xsd:string ;
+        sh:name "Reaction"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # FHIR R4 AllergyIntoleranceSeverity
+    sh:property [
+        sh:path health:allergySeverity ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("mild" "moderate" "severe") ;
+        sh:name "Allergy Severity"@en ;
+        sh:message "Allergy severity must be one of the FHIR R4 AllergyIntoleranceSeverity codes: mild, moderate, severe"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # FHIR R4 AllergyIntoleranceCategory
+    sh:property [
+        sh:path health:allergyCategory ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("food" "medication" "environment" "biologic") ;
+        sh:name "Allergy Category"@en ;
+        sh:message "Allergy category must be one of the FHIR R4 AllergyIntoleranceCategory codes: food, medication, environment, biologic"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:onsetDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Onset Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Allergy must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Allergy must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 12: Immunization Record
+# ============================================================================
+
+health:ImmunizationRecordShape a sh:NodeShape ;
+    sh:targetClass health:ImmunizationRecord ;
+    rdfs:label "Immunization Record Shape"@en ;
+    rdfs:comment "Validation constraints for immunization records. Lifted from clinical:ImmunizationShape and checked against FHIR R4 Immunization."@en ;
+
+    # REQUIRED: vaccineName
+    sh:property [
+        sh:path health:vaccineName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Vaccine Name"@en ;
+        sh:message "Immunization must have exactly one non-empty vaccineName"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # NOT required here although FHIR R4 Immunization.occurrence is 1..1.
+    # clinical:ImmunizationShape constrains no date at all, so requiring one
+    # would be a new constraint rather than a lifted one, and would newly fail
+    # existing records. Promoting this to sh:minCount 1 is a candidate for a
+    # release that is explicitly flagged as tightening.
+    sh:property [
+        sh:path health:administrationDate ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Administration Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # FHIR R4 ImmunizationStatusCodes
+    sh:property [
+        sh:path health:status ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:in ("completed" "entered-in-error" "not-done") ;
+        sh:name "Status"@en ;
+        sh:message "Immunization status must be one of the FHIR R4 ImmunizationStatusCodes: completed, entered-in-error, not-done"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:vaccineCode ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Vaccine Code"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:manufacturer ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Manufacturer"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:lotNumber ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Lot Number"@en ;
+        sh:message "Immunization must not carry more than one lotNumber; a lot number identifies a single administered dose"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:doseQuantity ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Dose Quantity"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:route ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Route"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:site ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Administration Site"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:administeringProvider ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Administering Provider"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:administeringLocation ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Administering Location"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Immunization must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Immunization must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Shape 13: Family History Record
+# ============================================================================
+#
+# There is no clinical:FamilyHistory class and therefore no shape to lift from.
+# Constraints here are derived directly from FHIR R4 FamilyMemberHistory, whose
+# relationship element is 1..1 and whose condition.code is required within each
+# condition entry. The provenance and schemaVersion blocks follow the same
+# pattern as every other record shape.
+
+health:FamilyHistoryRecordShape a sh:NodeShape ;
+    sh:targetClass health:FamilyHistoryRecord ;
+    rdfs:label "Family History Record Shape"@en ;
+    rdfs:comment "Validation constraints for family history records. Derived from FHIR R4 FamilyMemberHistory."@en ;
+
+    # REQUIRED: conditionName (FHIR condition.code is required per entry)
+    sh:property [
+        sh:path health:conditionName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Condition Name"@en ;
+        sh:message "Family history record must name exactly one condition"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # REQUIRED: relationship (FHIR FamilyMemberHistory.relationship is 1..1).
+    # A condition with no stated relative is not family history.
+    sh:property [
+        sh:path clinical:relationship ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:name "Relationship"@en ;
+        sh:message "Family history record must state exactly one relationship to the patient"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:onsetAge ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 130 ;
+        sh:name "Onset Age"@en ;
+        sh:message "Onset age must be a single integer between 0 and 130"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:sourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Source Record Identifier"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:dataProvenance ;
+        sh:in (cascade:ClinicalGenerated cascade:EHRVerified cascade:DeviceGenerated
+               cascade:PatientReported cascade:SelfReported cascade:AIExtracted) ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Data Provenance"@en ;
+        sh:message "Family history record must declare exactly one valid cascade:dataProvenance"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:schemaVersion ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^[0-9]+\\.[0-9]+$" ;
+        sh:name "Schema Version"@en ;
+        sh:message "Family history record must declare exactly one schemaVersion in major.minor form"@en ;
+        sh:severity sh:Violation
+    ] .
+
+# ============================================================================
+# Daily Snapshot Shapes (v1.2 — health v2.5)
+# ============================================================================
+#
+# These three classes were defined in health v2.0 and have been emitted ever
+# since, but no shape targeted them, so every reading in every history
+# container validated vacuously.
+#
+# health:DailyVitalReading is emitted in TWO forms that do not share their
+# value and date predicates:
+#
+#   Pattern A (HealthProfileSerializer): health:value, health:unit, health:date
+#   Pattern B (reference pod):           fhir:valueQuantity, cascade:date
+#
+# Both are live. The shape therefore requires a date and a value through
+# sh:or rather than naming one spelling and failing the other. Reconciling the
+# two serializations is a separate change; constraining one of them here would
+# have silently invalidated the other.
+
+health:DailyVitalReadingShape a sh:NodeShape ;
+    sh:targetClass health:DailyVitalReading ;
+    rdfs:label "Daily Vital Reading Shape"@en ;
+    rdfs:comment "Validation constraints for a single day's aggregated vital sign reading inside a history container."@en ;
+
+    # REQUIRED: a timestamp, in either spelling. A reading with no date cannot
+    # be placed in the time series it lives in.
+    sh:or (
+        [ sh:property [ sh:path cascade:date ; sh:minCount 1 ] ]
+        [ sh:property [ sh:path health:date  ; sh:minCount 1 ] ]
+    ) ;
+    sh:message "Daily vital reading must carry a timestamp as either cascade:date or health:date"@en ;
+    sh:severity sh:Violation ;
+
+    sh:property [
+        sh:path cascade:date ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:date ;
+        sh:datatype xsd:dateTime ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:sampleCount ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:name "Sample Count"@en ;
+        sh:message "Sample count must be a single non-negative integer"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:value ;
+        sh:maxCount 1 ;
+        sh:name "Value"@en ;
+        sh:message "Daily vital reading must not carry more than one value"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:unit ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+        sh:name "Unit"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path cascade:loincCode ;
+        sh:maxCount 1 ;
+        sh:name "LOINC Code"@en ;
+        sh:severity sh:Violation
+    ] .
+
+health:DailyActivitySnapshotShape a sh:NodeShape ;
+    sh:targetClass health:DailyActivitySnapshot ;
+    rdfs:label "Daily Activity Snapshot Shape"@en ;
+    rdfs:comment "Validation constraints for a single day's activity metrics."@en ;
+
+    sh:property [
+        sh:path cascade:date ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:message "Daily activity snapshot must carry exactly one cascade:date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:steps ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:name "Steps"@en ;
+        sh:message "Steps must be a single non-negative integer"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:activeEnergyKcal ;
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:name "Active Energy (kcal)"@en ;
+        sh:message "Active energy must be a single non-negative decimal"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:exerciseMinutes ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 1440 ;
+        sh:name "Exercise Minutes"@en ;
+        sh:message "Exercise minutes must be a single integer between 0 and 1440"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:standHours ;
+        sh:datatype xsd:integer ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 24 ;
+        sh:name "Stand Hours"@en ;
+        sh:message "Stand hours must be a single integer between 0 and 24"@en ;
+        sh:severity sh:Violation
+    ] .
+
+health:DailySleepSnapshotShape a sh:NodeShape ;
+    sh:targetClass health:DailySleepSnapshot ;
+    rdfs:label "Daily Sleep Snapshot Shape"@en ;
+    rdfs:comment "Validation constraints for a single night's sleep metrics."@en ;
+
+    sh:property [
+        sh:path cascade:date ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:name "Date"@en ;
+        sh:message "Daily sleep snapshot must carry exactly one cascade:date"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    sh:property [
+        sh:path health:durationHours ;
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 24 ;
+        sh:name "Sleep Duration (hours)"@en ;
+        sh:message "Sleep duration must be a single decimal between 0 and 24 hours"@en ;
+        sh:severity sh:Violation
+    ] ;
+
+    # No sh:datatype: health:sleepQuality is declared owl:DatatypeProperty with
+    # rdfs:range xsd:string in health.ttl, but every known emitter writes an
+    # IRI. Asserting either form here would contradict something real, so the
+    # shape constrains cardinality and the permitted individuals only.
+    sh:property [
+        sh:path health:sleepQuality ;
+        sh:maxCount 1 ;
+        sh:in (health:Excellent health:Good health:Fair health:Poor) ;
+        sh:name "Sleep Quality"@en ;
+        sh:message "Sleep quality must be one of health:Excellent, health:Good, health:Fair, health:Poor"@en ;
+        sh:severity sh:Violation
+    ] .

--- a/ontologies/health/v1/health.ttl
+++ b/ontologies/health/v1/health.ttl
@@ -21,8 +21,8 @@
     dct:description "Vocabulary for consumer-generated wellness observations from wearable devices and HealthKit. Maps Cascade wellness properties to established SNOMED CT and LOINC codes following the three-layer ontology architecture."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-01-29"^^xsd:date ;
-    dct:modified "2026-03-27"^^xsd:date ;
-    owl:versionInfo "2.4" ;
+    dct:modified "2026-08-03"^^xsd:date ;
+    owl:versionInfo "2.5" ;
     rdfs:comment """Three-layer ontology for wellness data:
         Layer 1 (Established standards): SNOMED CT concept IDs + LOINC observation codes
         Layer 2 (Cascade health vocabulary): health: namespace properties linking to Layer 1
@@ -30,6 +30,21 @@
     rdfs:seeAlso <https://cascadeprotocol.org/docs/health/v1/> .
 
 # Changelog:
+# v2.5 (2026-08-03): Clinical record classes. Five classes that serializers have
+#     emitted since v1.3 but that this ontology never defined are now defined:
+#     health:LabResultRecord, health:ConditionRecord, health:AllergyRecord,
+#     health:ImmunizationRecord, health:FamilyHistoryRecord. Adds the 40
+#     properties they use (previously undefined vocabulary), 4 sleep-quality
+#     named individuals, and 6 wellness container classes
+#     (health:ActivityData, SleepData, HeartRateData, BloodPressureData,
+#     HRVData, BodyMeasurements) as rdfs:subClassOf health:HealthProfile.
+#     The subclass declarations make the existing rdfs:domain health:HealthProfile
+#     on the eight history container properties true rather than contradicted,
+#     and bring those containers under health:HealthProfileShape through
+#     SHACL subclass-aware sh:targetClass. Adds a namespace-boundary note
+#     explaining that health: vs clinical: is historical, not a provenance
+#     signal. No serializer changes; every term here was already being emitted.
+#
 # v2.4 (2026-03-27): EHR Import Reconciliation (P1-C) — Added health:SocialHistoryRecord
 #     class for social history observations (smoking, alcohol, exercise, occupation).
 #     Added 4 properties: health:smokingStatus, health:alcoholUse,
@@ -965,3 +980,510 @@ health:occupationalExposure a owl:DatatypeProperty ;
     rdfs:comment "Occupational exposures relevant to patient health."@en ;
     rdfs:domain health:SocialHistoryRecord ;
     rdfs:range xsd:string .
+
+# ============================================================================
+# Namespace Boundary Note (v2.5)
+# ============================================================================
+#
+# The split between the health: and clinical: namespaces is HISTORICAL, not
+# semantic. It is not a provenance signal and must not be read as one.
+#
+# health: was introduced for consumer- and device-generated wellness data and
+# clinical: for EHR-sourced records, but serializers have never honoured that
+# division. Records typed health:LabResultRecord, health:ConditionRecord,
+# health:AllergyRecord and health:ImmunizationRecord carry EHR-sourced data,
+# and clinical:VitalSign records carry consumer-device data.
+#
+# PROVENANCE IS CARRIED BY cascade:dataProvenance, AND ONLY BY IT.
+# Consumers deciding whether a record came from an EHR, a device, or the
+# patient MUST key on cascade:dataProvenance (ClinicalGenerated, EHRVerified,
+# DeviceGenerated, PatientReported, SelfReported, AIExtracted). Keying on the
+# namespace of the rdf:type will give the wrong answer on real pods.
+#
+# Both namespaces are ratified and neither is being migrated. The clinical:
+# classes that duplicate the five classes defined below are deprecated in
+# clinical v1.13 (owl:deprecated true, rdfs:seeAlso pointing here) but are NOT
+# removed: an existing export path still emits them and existing pods contain
+# them. Readers must accept both spellings; writers should prefer these.
+#
+# ---------------------------------------------------------------------------
+# SocialHistoryRecord: two classes, deliberately kept
+# ---------------------------------------------------------------------------
+#
+# health:SocialHistoryRecord (v2.4, above) and clinical:SocialHistoryRecord
+# (clinical v1.9) both exist and both are retained. The asserted
+# consumer-versus-EHR division does not describe what is emitted:
+#
+#   - clinical:SocialHistoryRecord is emitted, by the free-text LLM extraction
+#     path only.
+#   - health:SocialHistoryRecord is emitted by nothing. The structured C-CDA
+#     Social History path that appears to write it reports the entries it read
+#     but writes no records at all, so the class is defined and shaped but
+#     never instantiated.
+#
+# Neither class is therefore a reliable indicator of how a social-history
+# observation was obtained. Consumers should accept both types and read
+# cascade:dataProvenance for the actual source. Reconciling the two is
+# deferred rather than guessed at.
+
+# ============================================================================
+# Clinical Record Classes (v2.5)
+# ============================================================================
+#
+# These five classes have been emitted by Cascade serializers since schema
+# version 1.3 but were never defined in this ontology. Defining them is purely
+# additive: no serializer changes, no rdf:type changes, no pod migration. It
+# makes existing data describable and, with health.shapes.ttl v1.2, checkable.
+#
+# Layer 1 alignment: each class states the FHIR R4 resource it corresponds to.
+# Layer 2: the properties below. Layer 3: checkup:/pots: aggregations.
+
+health:LabResultRecord a owl:Class ;
+    rdfs:label "Lab Result Record"@en ;
+    rdfs:comment "A laboratory test result: the test performed, its value and unit, the reference range it is read against, and the specimen it came from. Emitted for both EHR-imported and patient-entered results; read cascade:dataProvenance to tell them apart."@en ;
+    rdfs:subClassOf fhir:Observation ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/observation.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:ConditionRecord a owl:Class ;
+    rdfs:label "Condition Record"@en ;
+    rdfs:comment "A diagnosed condition or problem-list entry, with its clinical status, onset, and coding. Emitted for both EHR-imported and self-reported conditions; read cascade:dataProvenance to tell them apart."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/condition.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:AllergyRecord a owl:Class ;
+    rdfs:label "Allergy Record"@en ;
+    rdfs:comment "An allergy or intolerance: the allergen, the reaction it provokes, and the severity of that reaction. Emitted for both EHR-imported and self-reported allergies; read cascade:dataProvenance to tell them apart."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/allergyintolerance.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:ImmunizationRecord a owl:Class ;
+    rdfs:label "Immunization Record"@en ;
+    rdfs:comment "An administered vaccine dose, with product identification, lot, route, site and administering party."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/immunization.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+health:FamilyHistoryRecord a owl:Class ;
+    rdfs:label "Family History Record"@en ;
+    rdfs:comment "A condition recorded for a relative of the patient, with the relationship and the relative's age at onset. The relationship is expressed with clinical:relationship, which is shared with coverage records."@en ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/familymemberhistory.html> ;
+    owl:versionInfo "Added in health v2.5; emitted since schema 1.3" .
+
+# ----------------------------------------------------------------------------
+# Properties shared across the record classes
+# ----------------------------------------------------------------------------
+# Domains are unions rather than a single class. A single-class rdfs:domain on
+# a property that several classes use is an assertion the data falsifies, which
+# is the defect this release is correcting elsewhere; do not reintroduce it.
+
+health:notes a owl:DatatypeProperty ;
+    rdfs:label "Notes"@en ;
+    rdfs:comment "Free-text clinical or patient commentary attached to a record."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf (
+        health:LabResultRecord health:ConditionRecord health:AllergyRecord
+        health:ImmunizationRecord health:FamilyHistoryRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:sourceRecordId a owl:DatatypeProperty ;
+    rdfs:label "Source Record Identifier"@en ;
+    rdfs:comment "Identifier of this record in the system it was imported from. Opaque to Cascade; used for reconciliation against the source system, not as a Cascade identity."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf (
+        health:LabResultRecord health:ConditionRecord health:AllergyRecord
+        health:ImmunizationRecord health:FamilyHistoryRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:status a owl:DatatypeProperty ;
+    rdfs:label "Status"@en ;
+    rdfs:comment "Lifecycle status of the record. The permitted values differ by class and are constrained per-shape, not here: condition records use the FHIR R4 ConditionClinicalStatusCodes value set, immunization records use ImmunizationStatusCodes."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf ( health:ConditionRecord health:ImmunizationRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:onsetDate a owl:DatatypeProperty ;
+    rdfs:label "Onset Date"@en ;
+    rdfs:comment "When the condition or allergy began, or was first recorded as beginning."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf ( health:ConditionRecord health:AllergyRecord ) ] ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:conditionName a owl:DatatypeProperty ;
+    rdfs:label "Condition Name"@en ;
+    rdfs:comment "Human-readable name of the condition. Used both for the patient's own conditions and for conditions recorded against a relative."@en ;
+    rdfs:domain [ a owl:Class ; owl:unionOf ( health:ConditionRecord health:FamilyHistoryRecord ) ] ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Lab result properties
+# ----------------------------------------------------------------------------
+
+health:testName a owl:DatatypeProperty ;
+    rdfs:label "Test Name"@en ;
+    rdfs:comment "Human-readable name of the laboratory test performed."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:resultValue a owl:DatatypeProperty ;
+    rdfs:label "Result Value"@en ;
+    rdfs:comment "The measured value. Carried as a string because lab results are not uniformly numeric: ratios, titres, qualitative results ('Negative'), and bounded values ('<0.01') all occur. Exactly one value per record."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:resultUnit a owl:DatatypeProperty ;
+    rdfs:label "Result Unit"@en ;
+    rdfs:comment "Unit of measure for health:resultValue, as reported by the performing laboratory."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <http://unitsofmeasure.org/> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:interpretation a owl:DatatypeProperty ;
+    rdfs:label "Interpretation"@en ;
+    rdfs:comment "Categorical reading of the result against its reference range."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-observation-interpretation.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:performedDate a owl:DatatypeProperty ;
+    rdfs:label "Performed Date"@en ;
+    rdfs:comment "When the specimen was collected or the test performed. Distinct from health:reportedDate."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:reportedDate a owl:DatatypeProperty ;
+    rdfs:label "Reported Date"@en ;
+    rdfs:comment "When the laboratory released the result. Later than health:performedDate."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:testCode a owl:ObjectProperty ;
+    rdfs:label "Test Code"@en ;
+    rdfs:comment "LOINC reference for the test performed, as an IRI."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:seeAlso <http://loinc.org/> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:labCategory a owl:DatatypeProperty ;
+    rdfs:label "Lab Category"@en ;
+    rdfs:comment "Laboratory department or panel grouping (for example Chemistry, Hematology). Free text: laboratories do not agree on a common set."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:referenceRange a owl:DatatypeProperty ;
+    rdfs:label "Reference Range"@en ;
+    rdfs:comment "The normal range this result is read against, as printed by the performing laboratory (for example '70 - 100'). Not parsed."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:specimenType a owl:DatatypeProperty ;
+    rdfs:label "Specimen Type"@en ;
+    rdfs:comment "The specimen the test was run on (for example Serum, Whole Blood, Urine)."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:orderingProvider a owl:DatatypeProperty ;
+    rdfs:label "Ordering Provider"@en ;
+    rdfs:comment "Name of the clinician who ordered the test."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:performingLab a owl:DatatypeProperty ;
+    rdfs:label "Performing Laboratory"@en ;
+    rdfs:comment "Name of the laboratory that ran the test."@en ;
+    rdfs:domain health:LabResultRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Condition properties
+# ----------------------------------------------------------------------------
+
+health:icd10Code a owl:ObjectProperty ;
+    rdfs:label "ICD-10-CM Code"@en ;
+    rdfs:comment "ICD-10-CM reference for the condition, as an IRI."@en ;
+    rdfs:domain health:ConditionRecord ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/codesystem-icd10.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:conditionClass a owl:DatatypeProperty ;
+    rdfs:label "Condition Class"@en ;
+    rdfs:comment "Body-system grouping used for patient-facing organisation (for example cardiovascular, endocrine, respiratory). A presentation aid, not a clinical classification; do not use it for decision support."@en ;
+    rdfs:domain health:ConditionRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:monitoredVitalSigns a owl:ObjectProperty ;
+    rdfs:label "Monitored Vital Signs"@en ;
+    rdfs:comment "Ordered list of vital-sign names a patient or app tracks because of this condition (for example bloodPressure, heartRate). An rdf:List of string literals."@en ;
+    rdfs:domain health:ConditionRecord ;
+    rdfs:range rdf:List ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Allergy properties
+# ----------------------------------------------------------------------------
+
+health:allergen a owl:DatatypeProperty ;
+    rdfs:label "Allergen"@en ;
+    rdfs:comment "The substance the patient reacts to. Required: an allergy record without an allergen carries no safety information."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:allergyCategory a owl:DatatypeProperty ;
+    rdfs:label "Allergy Category"@en ;
+    rdfs:comment "Category of the allergen, using the FHIR R4 AllergyIntoleranceCategory value set: food, medication, environment, biologic."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-allergy-intolerance-category.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:reaction a owl:DatatypeProperty ;
+    rdfs:label "Reaction"@en ;
+    rdfs:comment "Description of the manifestation the allergen produces (for example 'Hives (urticaria)')."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:allergySeverity a owl:DatatypeProperty ;
+    rdfs:label "Allergy Severity"@en ;
+    rdfs:comment "Severity of the reaction as a whole, using the FHIR R4 AllergyIntoleranceSeverity value set: mild, moderate, severe."@en ;
+    rdfs:domain health:AllergyRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-reaction-event-severity.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Immunization properties
+# ----------------------------------------------------------------------------
+
+health:vaccineName a owl:DatatypeProperty ;
+    rdfs:label "Vaccine Name"@en ;
+    rdfs:comment "Human-readable name of the vaccine product administered."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:administrationDate a owl:DatatypeProperty ;
+    rdfs:label "Administration Date"@en ;
+    rdfs:comment "When the dose was administered. Corresponds to FHIR R4 Immunization.occurrence, which is 1..1."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:dateTime ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:vaccineCode a owl:DatatypeProperty ;
+    rdfs:label "Vaccine Code"@en ;
+    rdfs:comment "Coded identifier for the vaccine product, typically a CVX code."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-vaccine-code.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:manufacturer a owl:DatatypeProperty ;
+    rdfs:label "Manufacturer"@en ;
+    rdfs:comment "Manufacturer of the administered vaccine product."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:lotNumber a owl:DatatypeProperty ;
+    rdfs:label "Lot Number"@en ;
+    rdfs:comment "Manufacturer lot number of the administered dose. Required for recall tracing."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:doseQuantity a owl:DatatypeProperty ;
+    rdfs:label "Dose Quantity"@en ;
+    rdfs:comment "Amount administered, value and unit together as printed (for example '0.5 mL')."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:route a owl:DatatypeProperty ;
+    rdfs:label "Route"@en ;
+    rdfs:comment "Route of administration (for example intramuscular, oral, intranasal)."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://hl7.org/fhir/R4/valueset-immunization-route.html> ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:site a owl:DatatypeProperty ;
+    rdfs:label "Administration Site"@en ;
+    rdfs:comment "Body site the dose was administered at (for example 'Left deltoid')."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:administeringProvider a owl:DatatypeProperty ;
+    rdfs:label "Administering Provider"@en ;
+    rdfs:comment "Name of the person who administered the dose."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:administeringLocation a owl:DatatypeProperty ;
+    rdfs:label "Administering Location"@en ;
+    rdfs:comment "Facility where the dose was administered."@en ;
+    rdfs:domain health:ImmunizationRecord ;
+    rdfs:range xsd:string ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Family history properties
+# ----------------------------------------------------------------------------
+
+health:onsetAge a owl:DatatypeProperty ;
+    rdfs:label "Onset Age"@en ;
+    rdfs:comment "Age in years at which the relative's condition began. Corresponds to FHIR R4 FamilyMemberHistory.condition.onsetAge."@en ;
+    rdfs:domain health:FamilyHistoryRecord ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ============================================================================
+# Wellness Container Classes (v2.5)
+# ============================================================================
+#
+# Six containers that HealthProfileSerializer has always emitted at /wellness/.
+# Each is a partition of a health profile carrying one family of history
+# containers. Declaring them subclasses of health:HealthProfile does two things:
+#
+#   1. It makes the rdfs:domain health:HealthProfile already asserted on the
+#      eight history container properties above TRUE. Before this release those
+#      domain statements were contradicted by every pod ever written, because
+#      health:dailyActivityHistory is emitted on a health:ActivityData subject,
+#      never on a health:HealthProfile subject.
+#   2. It brings these subjects under health:HealthProfileShape, whose
+#      sh:targetClass is subclass-aware per SHACL 2.1.3.1.
+#
+# No serializer changes. No rdf:type changes. These subjects were already
+# being written with exactly these types.
+
+health:ActivityData a owl:Class ;
+    rdfs:label "Activity Data"@en ;
+    rdfs:comment "Wellness container for daily activity history: steps, active energy, exercise minutes and stand hours."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:SleepData a owl:Class ;
+    rdfs:label "Sleep Data"@en ;
+    rdfs:comment "Wellness container for nightly sleep history: duration and quality."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:HeartRateData a owl:Class ;
+    rdfs:label "Heart Rate Data"@en ;
+    rdfs:comment "Wellness container for resting and walking heart rate history."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:BloodPressureData a owl:Class ;
+    rdfs:label "Blood Pressure Data"@en ;
+    rdfs:comment "Wellness container for blood pressure history from home monitors."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:HRVData a owl:Class ;
+    rdfs:label "HRV Data"@en ;
+    rdfs:comment "Wellness container for heart rate variability (SDNN) history."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+health:BodyMeasurements a owl:Class ;
+    rdfs:label "Body Measurements"@en ;
+    rdfs:comment "Wellness container for body mass and related anthropometric history."@en ;
+    rdfs:subClassOf health:HealthProfile ;
+    owl:versionInfo "Added in health v2.5; emitted since health v2.0" .
+
+# ============================================================================
+# Daily Snapshot Properties (v2.5)
+# ============================================================================
+#
+# Emitted on health:DailyActivitySnapshot and health:DailySleepSnapshot entries
+# inside the history containers. These are the single-day forms. The similarly
+# named health:activeEnergyBurnedKcal, health:exerciseMinutesWeekly and
+# health:standHoursDaily above are the 7-day aggregate forms carried on
+# health:ActivitySnapshot; the two sets are distinct and both are emitted.
+
+health:steps a owl:DatatypeProperty ;
+    rdfs:label "Steps"@en ;
+    rdfs:comment "Step count for a single day."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:activeEnergyKcal a owl:DatatypeProperty ;
+    rdfs:label "Active Energy (kcal)"@en ;
+    rdfs:comment "Active energy burned in kilocalories for a single day."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:decimal ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:exerciseMinutes a owl:DatatypeProperty ;
+    rdfs:label "Exercise Minutes"@en ;
+    rdfs:comment "Minutes of exercise recorded for a single day."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:standHours a owl:DatatypeProperty ;
+    rdfs:label "Stand Hours"@en ;
+    rdfs:comment "Hours in which standing was recorded for a single day. Bounded 0-24."@en ;
+    rdfs:domain health:DailyActivitySnapshot ;
+    rdfs:range xsd:integer ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:durationHours a owl:DatatypeProperty ;
+    rdfs:label "Sleep Duration (hours)"@en ;
+    rdfs:comment "Total sleep duration in hours for a single night."@en ;
+    rdfs:domain health:DailySleepSnapshot ;
+    rdfs:range xsd:decimal ;
+    owl:versionInfo "Added in health v2.5" .
+
+# ----------------------------------------------------------------------------
+# Sleep quality individuals (v2.5)
+# ----------------------------------------------------------------------------
+#
+# health:sleepQuality is emitted with an IRI object, not a string literal:
+# HealthProfileSerializer writes `health:sleepQuality health:Good` and
+# HealthProfileDeserializer parses exactly that form. The four individuals it
+# ranges over were never defined. They are defined here.
+#
+# health:sleepQuality itself is left declared as it was (see above). Its
+# rdfs:range xsd:string does not describe what is emitted, and no known emitter
+# produces the string form, but correcting the declaration is a separate change
+# with its own compatibility question and is deferred rather than bundled here.
+# health:DailySleepSnapshotShape therefore constrains this property's
+# cardinality and permitted values but asserts no datatype.
+
+health:SleepQuality a owl:Class ;
+    rdfs:label "Sleep Quality"@en ;
+    rdfs:comment "Qualitative classification of a night's sleep, as derived by the recording device."@en ;
+    owl:versionInfo "Added in health v2.5" .
+
+health:Excellent a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Excellent"@en ;
+    rdfs:comment "Sleep quality classified as excellent."@en .
+
+health:Good a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Good"@en ;
+    rdfs:comment "Sleep quality classified as good."@en .
+
+health:Fair a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Fair"@en ;
+    rdfs:comment "Sleep quality classified as fair."@en .
+
+health:Poor a owl:NamedIndividual, health:SleepQuality ;
+    rdfs:label "Poor"@en ;
+    rdfs:comment "Sleep quality classified as poor."@en .

--- a/scripts/check-downstream-versions.sh
+++ b/scripts/check-downstream-versions.sh
@@ -1,8 +1,22 @@
 #!/bin/sh
 # check-downstream-versions.sh
-# Reads the canonical VOCAB_VERSIONS from spec/ and compares it against
-# the VOCAB_VERSIONS files in each downstream repository.
-# Reports any repos that are behind.
+#
+# Compares the canonical vocabulary versions against every downstream repository.
+#
+# CANONICAL SOURCE OF TRUTH: the VOCAB_VERSIONS file as it exists on the
+# integration branch (`origin/main`, falling back to `main`) -- NOT the working
+# tree. A checkout sitting on an unmerged feature branch would otherwise launder
+# that branch's proposed version numbers into "canonical", and every downstream
+# repo would be reported as drifted against a number no one has ratified.
+#
+# The same rule is applied to each downstream repo: its VOCAB_VERSIONS is read
+# from its own integration branch, so an unmerged sync branch is reported as
+# UNMERGED rather than silently counted as done.
+#
+# Overrides:
+#   VOCAB_CANONICAL_REF=<ref>   use <ref> instead of origin/main / main
+#   VOCAB_ALLOW_WORKTREE=1      read working-tree files instead of git refs
+#                               (for tarball checkouts / CI without full history)
 #
 # Usage: ./scripts/check-downstream-versions.sh
 
@@ -10,62 +24,188 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SPEC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEV_ROOT="$(cd "$SPEC_ROOT/.." && pwd)"
 
-SPEC_VERSIONS="$SPEC_ROOT/VOCAB_VERSIONS"
-if [ ! -f "$SPEC_VERSIONS" ]; then
-  echo "Error: VOCAB_VERSIONS not found at $SPEC_VERSIONS"
+SPEC_VERSIONS_FILE="$SPEC_ROOT/VOCAB_VERSIONS"
+ALLOW_WORKTREE="${VOCAB_ALLOW_WORKTREE:-0}"
+
+warn() {
+  echo "$@" >&2
+}
+
+# resolve_ref <repo_path>
+# Echoes the integration ref to read VOCAB_VERSIONS from, or nothing if the
+# path is not a git repository / has no such ref.
+resolve_ref() {
+  _repo="$1"
+  git -C "$_repo" rev-parse --git-dir >/dev/null 2>&1 || return 1
+
+  if [ -n "${VOCAB_CANONICAL_REF:-}" ]; then
+    if git -C "$_repo" rev-parse --verify --quiet "$VOCAB_CANONICAL_REF" >/dev/null 2>&1; then
+      echo "$VOCAB_CANONICAL_REF"
+      return 0
+    fi
+    return 1
+  fi
+
+  for _candidate in origin/main main origin/master master; do
+    if git -C "$_repo" rev-parse --verify --quiet "$_candidate" >/dev/null 2>&1; then
+      echo "$_candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# read_versions <repo_path> <out_file>
+# Writes the comment-stripped VOCAB_VERSIONS body to <out_file>.
+# Echoes a human-readable description of where it came from.
+# Returns non-zero if no VOCAB_VERSIONS could be read at all.
+read_versions() {
+  _repo="$1"
+  _out="$2"
+
+  if [ "$ALLOW_WORKTREE" != "1" ]; then
+    _ref="$(resolve_ref "$_repo")"
+    if [ -n "$_ref" ] && git -C "$_repo" show "$_ref:VOCAB_VERSIONS" > "$_out.raw" 2>/dev/null; then
+      grep -v '^#' "$_out.raw" | grep -v '^[[:space:]]*$' > "$_out"
+      rm -f "$_out.raw"
+      echo "$_ref"
+      return 0
+    fi
+    rm -f "$_out.raw"
+  fi
+
+  if [ -f "$_repo/VOCAB_VERSIONS" ]; then
+    grep -v '^#' "$_repo/VOCAB_VERSIONS" | grep -v '^[[:space:]]*$' > "$_out"
+    echo "working tree"
+    return 0
+  fi
+
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Canonical versions, read from spec's integration branch
+# ---------------------------------------------------------------------------
+
+SPEC_CANONICAL="$(mktemp)"
+SPEC_SOURCE="$(read_versions "$SPEC_ROOT" "$SPEC_CANONICAL")"
+if [ -z "$SPEC_SOURCE" ]; then
+  echo "Error: could not read VOCAB_VERSIONS from $SPEC_ROOT (tried git refs and working tree)" >&2
+  rm -f "$SPEC_CANONICAL"
   exit 1
 fi
 
+if [ "$SPEC_SOURCE" = "working tree" ] && [ "$ALLOW_WORKTREE" != "1" ]; then
+  warn ""
+  warn "!! WARNING: canonical versions were read from the spec WORKING TREE."
+  warn "!! No integration ref (origin/main / main) was resolvable here, so these"
+  warn "!! numbers are whatever this checkout happens to contain and are NOT"
+  warn "!! proven to be ratified. Fetch the repo or set VOCAB_CANONICAL_REF."
+fi
+
 echo ""
-echo "Canonical vocab versions (spec):"
-grep -v '^#' "$SPEC_VERSIONS" | grep -v '^$' | while IFS='=' read -r key val; do
+echo "Canonical vocab versions (spec @ $SPEC_SOURCE):"
+while IFS='=' read -r key val; do
+  [ -n "$key" ] || continue
   echo "  $key = $val"
-done
+done < "$SPEC_CANONICAL"
 echo ""
+
+# ---------------------------------------------------------------------------
+# Loud warning when the spec working tree proposes versions main has not ratified
+# ---------------------------------------------------------------------------
+
+pending_spec=0
+if [ "$SPEC_SOURCE" != "working tree" ] && [ -f "$SPEC_VERSIONS_FILE" ]; then
+  SPEC_WORKTREE="$(mktemp)"
+  grep -v '^#' "$SPEC_VERSIONS_FILE" | grep -v '^[[:space:]]*$' > "$SPEC_WORKTREE"
+
+  pending_lines=""
+  while IFS='=' read -r vocab wt_ver; do
+    [ -n "$vocab" ] || continue
+    canon_ver=$(grep "^${vocab}=" "$SPEC_CANONICAL" | cut -d= -f2 | head -1)
+    [ -n "$canon_ver" ] || canon_ver="ABSENT"
+    if [ "$wt_ver" != "$canon_ver" ]; then
+      pending_lines="${pending_lines}!!   $vocab: working tree=$wt_ver  $SPEC_SOURCE=$canon_ver\n"
+    fi
+  done < "$SPEC_WORKTREE"
+  rm -f "$SPEC_WORKTREE"
+
+  if [ -n "$pending_lines" ]; then
+    pending_spec=1
+    branch=$(git -C "$SPEC_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    echo "!! ============================================================"
+    echo "!! SPEC WORKING TREE IS AHEAD OF $SPEC_SOURCE -- NOT YET CANONICAL"
+    echo "!! ============================================================"
+    echo "!!   branch: ${branch:-unknown}"
+    printf "%b" "$pending_lines"
+    echo "!!"
+    echo "!! These versions are PROPOSED, not ratified. Downstream repos below"
+    echo "!! are compared against $SPEC_SOURCE. Merge this branch, then re-run."
+    echo ""
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Downstream comparison
+# ---------------------------------------------------------------------------
 
 DOWNSTREAM_REPOS="cascade-cli sdk-typescript sdk-python cascade-agent conformance cascadeprotocol.org cascade-sdk-swift"
 any_drift=0
 
 for repo in $DOWNSTREAM_REPOS; do
   repo_path="$DEV_ROOT/$repo"
-  versions_file="$repo_path/VOCAB_VERSIONS"
 
   if [ ! -d "$repo_path" ]; then
     echo "[$repo] NOT FOUND at $repo_path"
     continue
   fi
 
-  if [ ! -f "$versions_file" ]; then
+  repo_versions="$(mktemp)"
+  repo_source="$(read_versions "$repo_path" "$repo_versions")"
+  if [ -z "$repo_source" ]; then
     echo "[$repo] MISSING VOCAB_VERSIONS file"
     any_drift=1
+    rm -f "$repo_versions"
     continue
   fi
 
   drift_lines=""
-  tmp_spec=$(mktemp)
-  grep -v '^#' "$SPEC_VERSIONS" | grep -v '^$' > "$tmp_spec"
   while IFS='=' read -r vocab spec_ver; do
-    repo_ver=$(grep "^${vocab}=" "$versions_file" | cut -d= -f2 | head -1)
-    if [ -z "$repo_ver" ]; then
-      repo_ver="MISSING"
-    fi
+    [ -n "$vocab" ] || continue
+    repo_ver=$(grep "^${vocab}=" "$repo_versions" | cut -d= -f2 | head -1)
+    [ -n "$repo_ver" ] || repo_ver="MISSING"
     if [ "$spec_ver" != "$repo_ver" ]; then
-      drift_lines="${drift_lines}  $vocab: repo=$repo_ver  spec=$spec_ver\n"
+      note=""
+      # If the repo's own working tree already carries the canonical value, the
+      # sync exists but is unmerged. Say so instead of implying no work was done.
+      if [ "$repo_source" != "working tree" ] && [ -f "$repo_path/VOCAB_VERSIONS" ]; then
+        wt_ver=$(grep "^${vocab}=" "$repo_path/VOCAB_VERSIONS" | cut -d= -f2 | head -1)
+        if [ "$wt_ver" = "$spec_ver" ]; then
+          note="  (working tree has $wt_ver -- UNMERGED)"
+        fi
+      fi
+      drift_lines="${drift_lines}  $vocab: repo=$repo_ver  spec=$spec_ver${note}\n"
     fi
-  done < "$tmp_spec"
-  rm -f "$tmp_spec"
+  done < "$SPEC_CANONICAL"
+  rm -f "$repo_versions"
 
   if [ -z "$drift_lines" ]; then
-    echo "[$repo] UP TO DATE"
+    echo "[$repo] UP TO DATE  (read from $repo_source)"
   else
-    echo "[$repo] DRIFT DETECTED:"
-    printf "%b\n" "$drift_lines"
+    echo "[$repo] DRIFT DETECTED  (read from $repo_source):"
+    printf "%b" "$drift_lines"
     any_drift=1
   fi
 done
 
+rm -f "$SPEC_CANONICAL"
+
 echo ""
-if [ "$any_drift" = "1" ]; then
+if [ "$pending_spec" = "1" ]; then
+  echo "Spec has UNMERGED version bumps. Downstream sync is blocked until they merge."
+  exit 1
+elif [ "$any_drift" = "1" ]; then
   echo "Action required: update VOCAB_VERSIONS in drifted repos and implement missing vocabulary support."
   exit 1
 else

--- a/scripts/test-check-downstream-versions.sh
+++ b/scripts/test-check-downstream-versions.sh
@@ -1,0 +1,329 @@
+#!/bin/sh
+# test-check-downstream-versions.sh
+#
+# Regression suite for check-downstream-versions.sh.
+#
+# The defect under test: the checker used to read VOCAB_VERSIONS as a plain file
+# path from the working tree, so a checkout sitting on an unmerged feature branch
+# reported that branch's proposed numbers as "Canonical" and every downstream
+# repo as drifted against a number nobody had ratified.
+#
+# Every assertion below is paired with a negative control: the same scenario is
+# replayed against the PREVIOUS version of the checker (read out of git history)
+# and must produce the wrong answer. A test that passes against both versions
+# proves nothing and is a bug in this file.
+#
+# Usage: ./scripts/test-check-downstream-versions.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SPEC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+NEW_SCRIPT="$SCRIPT_DIR/check-downstream-versions.sh"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+pass() { PASSED=$((PASSED + 1)); echo "  PASS  $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "  FAIL  $1"; echo "        $2"; }
+skip() { SKIPPED=$((SKIPPED + 1)); echo "  SKIP  $1  ($2)"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# Extract the previous checker from git history, for negative controls.
+# ---------------------------------------------------------------------------
+OLD_SCRIPT="$WORK/old-check.sh"
+OLD_AVAILABLE=1
+if ! git -C "$SPEC_ROOT" show "origin/main:scripts/check-downstream-versions.sh" > "$OLD_SCRIPT" 2>/dev/null; then
+  if ! git -C "$SPEC_ROOT" show "main:scripts/check-downstream-versions.sh" > "$OLD_SCRIPT" 2>/dev/null; then
+    OLD_AVAILABLE=0
+  fi
+fi
+[ "$OLD_AVAILABLE" = "1" ] && chmod +x "$OLD_SCRIPT"
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+mkrepo() {
+  # mkrepo <path> <versions-content>
+  _p="$1"; _c="$2"
+  mkdir -p "$_p"
+  git -C "$_p" init -b main >/dev/null 2>&1
+  printf '%s\n' "$_c" > "$_p/VOCAB_VERSIONS"
+  git -C "$_p" add -A >/dev/null 2>&1
+  git -C "$_p" -c user.email=t@t -c user.name=t commit -m init >/dev/null 2>&1
+}
+
+branch_bump() {
+  # branch_bump <path> <branch> <new-versions-content>
+  _p="$1"; _b="$2"; _c="$3"
+  git -C "$_p" checkout -b "$_b" >/dev/null 2>&1
+  printf '%s\n' "$_c" > "$_p/VOCAB_VERSIONS"
+  git -C "$_p" add -A >/dev/null 2>&1
+  git -C "$_p" -c user.email=t@t -c user.name=t commit -m bump >/dev/null 2>&1
+}
+
+# build_dev <name> -> echoes path to a synthetic DEV_ROOT containing spec/
+build_dev() {
+  _d="$WORK/$1"
+  mkdir -p "$_d"
+  echo "$_d"
+}
+
+install_checker() {
+  # install_checker <spec_path> <script>
+  mkdir -p "$1/scripts"
+  cp "$2" "$1/scripts/check-downstream-versions.sh"
+  chmod +x "$1/scripts/check-downstream-versions.sh"
+}
+
+VER_MAIN="core=3.3
+health=2.4
+clinical=1.12"
+
+VER_BRANCH="core=3.4
+health=2.5
+clinical=1.13"
+
+VER_OLD_DOWNSTREAM="core=3.3
+health=2.4
+clinical=1.9"
+
+echo ""
+echo "check-downstream-versions.sh regression suite"
+echo "============================================="
+echo ""
+
+# ===========================================================================
+echo "Scenario A: spec checkout on an UNMERGED branch that bumps all three vocabs"
+# ===========================================================================
+DEV_A="$(build_dev devA)"
+mkrepo "$DEV_A/spec" "$VER_MAIN"
+branch_bump "$DEV_A/spec" "feat/health-v2.5" "$VER_BRANCH"
+mkrepo "$DEV_A/cascade-cli" "$VER_MAIN"
+
+install_checker "$DEV_A/spec" "$NEW_SCRIPT"
+OUT_NEW="$(sh "$DEV_A/spec/scripts/check-downstream-versions.sh" 2>&1)"
+RC_NEW=$?
+
+# A1: canonical must be main's numbers, not the branch's
+if echo "$OUT_NEW" | grep -q "core = 3.3"; then
+  pass "A1 canonical core reads 3.3 from main, not 3.4 from the branch"
+else
+  fail "A1 canonical core reads 3.3 from main" "got: $(echo "$OUT_NEW" | grep -i 'core =')"
+fi
+
+# A1-NEG: the previous checker must get this WRONG
+if [ "$OLD_AVAILABLE" = "1" ]; then
+  install_checker "$DEV_A/spec" "$OLD_SCRIPT"
+  OUT_OLD="$(sh "$DEV_A/spec/scripts/check-downstream-versions.sh" 2>&1)"
+  RC_OLD=$?
+  install_checker "$DEV_A/spec" "$NEW_SCRIPT"
+  if echo "$OUT_OLD" | grep -q "core = 3.4"; then
+    pass "A1-NEG previous checker launders the branch (reports canonical core = 3.4)"
+  else
+    fail "A1-NEG previous checker should launder the branch" "old checker did not report 3.4; this test proves nothing. old output: $OUT_OLD"
+  fi
+else
+  skip "A1-NEG previous checker negative control" "could not read scripts/check-downstream-versions.sh from main"
+fi
+
+# A2: loud, machine-greppable warning that the working tree is not canonical
+if echo "$OUT_NEW" | grep -q "NOT YET CANONICAL"; then
+  pass "A2 warns loudly that the working tree is ahead of main"
+else
+  fail "A2 warns loudly that the working tree is ahead of main" "no NOT YET CANONICAL banner in output"
+fi
+
+# A3: the warning names the branch and every pending vocab
+A3_OK=1
+for tok in "feat/health-v2.5" "core: working tree=3.4" "health: working tree=2.5" "clinical: working tree=1.13"; do
+  echo "$OUT_NEW" | grep -q "$tok" || { A3_OK=0; A3_MISS="$tok"; }
+done
+if [ "$A3_OK" = "1" ]; then
+  pass "A3 warning names the branch and all three pending vocab bumps"
+else
+  fail "A3 warning names the branch and all three pending bumps" "missing token: $A3_MISS"
+fi
+
+# A3-NEG: the previous checker emits no such warning
+if [ "$OLD_AVAILABLE" = "1" ]; then
+  if echo "$OUT_OLD" | grep -q "NOT YET CANONICAL"; then
+    fail "A3-NEG previous checker should have no pending-branch warning" "old checker already warned; test proves nothing"
+  else
+    pass "A3-NEG previous checker emits no pending-branch warning"
+  fi
+else
+  skip "A3-NEG previous checker warning control" "old script unavailable"
+fi
+
+# A4: exit code is non-zero while a bump is unmerged
+if [ "$RC_NEW" -ne 0 ]; then
+  pass "A4 exits non-zero while the spec bump is unmerged (rc=$RC_NEW)"
+else
+  fail "A4 exits non-zero while the spec bump is unmerged" "rc=0"
+fi
+
+# A5: a downstream repo matching MAIN is not reported as drifted
+if echo "$OUT_NEW" | grep -q "\[cascade-cli\] UP TO DATE"; then
+  pass "A5 downstream repo matching main is UP TO DATE (not drifted against a branch)"
+else
+  fail "A5 downstream repo matching main is UP TO DATE" "got: $(echo "$OUT_NEW" | grep cascade-cli)"
+fi
+
+# A5-NEG: previous checker reports it as drifted against the unratified branch
+if [ "$OLD_AVAILABLE" = "1" ]; then
+  if echo "$OUT_OLD" | grep -q "\[cascade-cli\] DRIFT DETECTED"; then
+    pass "A5-NEG previous checker falsely drifts cascade-cli against the branch"
+  else
+    fail "A5-NEG previous checker should falsely drift cascade-cli" "old output: $(echo "$OUT_OLD" | grep cascade-cli)"
+  fi
+else
+  skip "A5-NEG previous checker drift control" "old script unavailable"
+fi
+
+echo ""
+# ===========================================================================
+echo "Scenario B: clean main, downstream in sync (distinctness: must differ from A)"
+# ===========================================================================
+DEV_B="$(build_dev devB)"
+mkrepo "$DEV_B/spec" "$VER_MAIN"
+mkrepo "$DEV_B/cascade-cli" "$VER_MAIN"
+install_checker "$DEV_B/spec" "$NEW_SCRIPT"
+OUT_B="$(sh "$DEV_B/spec/scripts/check-downstream-versions.sh" 2>&1)"
+RC_B=$?
+
+if [ "$RC_B" -eq 0 ] && echo "$OUT_B" | grep -q "All downstream repos are in sync"; then
+  pass "B1 clean main + synced downstream exits 0 and reports in sync"
+else
+  fail "B1 clean main + synced downstream exits 0" "rc=$RC_B"
+fi
+
+if echo "$OUT_B" | grep -q "NOT YET CANONICAL"; then
+  fail "B2 no pending-branch warning when on clean main" "banner appeared on a clean main"
+else
+  pass "B2 no pending-branch warning when on clean main"
+fi
+
+# Distinctness: A and B are genuinely different inputs and produce different output
+if [ "$OUT_NEW" != "$OUT_B" ]; then
+  pass "B3 distinctness: unmerged-branch output differs from clean-main output"
+else
+  fail "B3 distinctness" "identical output for two different repo states"
+fi
+
+echo ""
+# ===========================================================================
+echo "Scenario C: downstream genuinely behind"
+# ===========================================================================
+DEV_C="$(build_dev devC)"
+mkrepo "$DEV_C/spec" "$VER_MAIN"
+mkrepo "$DEV_C/cascade-cli" "$VER_OLD_DOWNSTREAM"
+install_checker "$DEV_C/spec" "$NEW_SCRIPT"
+OUT_C="$(sh "$DEV_C/spec/scripts/check-downstream-versions.sh" 2>&1)"
+RC_C=$?
+
+if [ "$RC_C" -ne 0 ] && echo "$OUT_C" | grep -q "clinical: repo=1.9  spec=1.12"; then
+  pass "C1 real downstream drift is still detected and named"
+else
+  fail "C1 real downstream drift is detected" "rc=$RC_C; $(echo "$OUT_C" | grep clinical)"
+fi
+
+echo ""
+# ===========================================================================
+echo "Scenario D: downstream sync exists but is UNMERGED"
+# ===========================================================================
+DEV_D="$(build_dev devD)"
+mkrepo "$DEV_D/spec" "$VER_MAIN"
+mkrepo "$DEV_D/cascade-cli" "$VER_OLD_DOWNSTREAM"
+branch_bump "$DEV_D/cascade-cli" "chore/sync-clinical" "$VER_MAIN"
+install_checker "$DEV_D/spec" "$NEW_SCRIPT"
+OUT_D="$(sh "$DEV_D/spec/scripts/check-downstream-versions.sh" 2>&1)"
+RC_D=$?
+
+if echo "$OUT_D" | grep -q "UNMERGED"; then
+  pass "D1 downstream sync on an unmerged branch is reported as UNMERGED"
+else
+  fail "D1 downstream unmerged sync is flagged" "$(echo "$OUT_D" | grep cascade-cli)"
+fi
+
+if [ "$RC_D" -ne 0 ]; then
+  pass "D2 unmerged downstream sync does not count as done (rc=$RC_D)"
+else
+  fail "D2 unmerged downstream sync must not exit 0" "rc=0"
+fi
+
+# D-NEG: previous checker calls the unmerged downstream sync UP TO DATE
+if [ "$OLD_AVAILABLE" = "1" ]; then
+  install_checker "$DEV_D/spec" "$OLD_SCRIPT"
+  OUT_D_OLD="$(sh "$DEV_D/spec/scripts/check-downstream-versions.sh" 2>&1)"
+  RC_D_OLD=$?
+  install_checker "$DEV_D/spec" "$NEW_SCRIPT"
+  if [ "$RC_D_OLD" -eq 0 ] && echo "$OUT_D_OLD" | grep -q "\[cascade-cli\] UP TO DATE"; then
+    pass "D-NEG previous checker calls the unmerged downstream sync UP TO DATE (rc=0)"
+  else
+    fail "D-NEG previous checker should call it UP TO DATE" "rc=$RC_D_OLD; $(echo "$OUT_D_OLD" | grep cascade-cli)"
+  fi
+else
+  skip "D-NEG previous checker unmerged-downstream control" "old script unavailable"
+fi
+
+echo ""
+# ===========================================================================
+echo "Scenario E: escape hatches"
+# ===========================================================================
+install_checker "$DEV_A/spec" "$NEW_SCRIPT"
+OUT_E1="$(VOCAB_ALLOW_WORKTREE=1 sh "$DEV_A/spec/scripts/check-downstream-versions.sh" 2>&1)"
+if echo "$OUT_E1" | grep -q "core = 3.4"; then
+  pass "E1 VOCAB_ALLOW_WORKTREE=1 restores working-tree reads for tarball checkouts"
+else
+  fail "E1 VOCAB_ALLOW_WORKTREE=1 reads the working tree" "$(echo "$OUT_E1" | grep -i 'core =')"
+fi
+
+OUT_E2="$(VOCAB_CANONICAL_REF=feat/health-v2.5 sh "$DEV_A/spec/scripts/check-downstream-versions.sh" 2>&1)"
+if echo "$OUT_E2" | grep -q "core = 3.4" && echo "$OUT_E2" | grep -q "spec @ feat/health-v2.5"; then
+  pass "E2 VOCAB_CANONICAL_REF pins an explicit ref and labels the source"
+else
+  fail "E2 VOCAB_CANONICAL_REF pins an explicit ref" "$(echo "$OUT_E2" | head -4)"
+fi
+
+# E3: a non-git directory falls back to the working tree with a stderr warning
+DEV_E="$(build_dev devE)"
+mkdir -p "$DEV_E/spec"
+printf '%s\n' "$VER_MAIN" > "$DEV_E/spec/VOCAB_VERSIONS"
+mkrepo "$DEV_E/cascade-cli" "$VER_MAIN"
+install_checker "$DEV_E/spec" "$NEW_SCRIPT"
+ERR_E3="$(sh "$DEV_E/spec/scripts/check-downstream-versions.sh" 2>&1 >/dev/null)"
+OUT_E3="$(sh "$DEV_E/spec/scripts/check-downstream-versions.sh" 2>/dev/null)"
+if echo "$ERR_E3" | grep -q "WARNING: canonical versions were read from the spec WORKING TREE" \
+   && echo "$OUT_E3" | grep -q "core = 3.3"; then
+  pass "E3 non-git checkout falls back to working tree and warns on stderr"
+else
+  fail "E3 non-git checkout warns on stderr" "stderr: $ERR_E3"
+fi
+
+echo ""
+# ===========================================================================
+echo "Scenario F: determinism"
+# ===========================================================================
+R1="$(cd / && sh "$DEV_C/spec/scripts/check-downstream-versions.sh" 2>&1)"
+R2="$(cd "$WORK" && sh "$DEV_C/spec/scripts/check-downstream-versions.sh" 2>&1)"
+R3="$(cd "$DEV_C" && sh "$DEV_C/spec/scripts/check-downstream-versions.sh" 2>&1)"
+if [ "$R1" = "$R2" ] && [ "$R2" = "$R3" ]; then
+  pass "F1 identical output from three separate processes in three working directories"
+else
+  fail "F1 determinism across cwd" "outputs differ"
+fi
+if [ "$R1" != "$OUT_B" ]; then
+  pass "F2 distinctness: the deterministic output is not a constant (drifted != synced)"
+else
+  fail "F2 distinctness" "drifted and synced repos produced identical output"
+fi
+
+echo ""
+echo "============================================="
+TOTAL=$((PASSED + FAILED + SKIPPED))
+echo "passed=$PASSED  failed=$FAILED  skipped=$SKIPPED  total=$TOTAL"
+[ "$FAILED" -eq 0 ] || exit 1


### PR DESCRIPTION
Defines vocabulary that Cascade serializers have emitted since schema 1.3 but that the ontologies never declared, and shapes it. **Additive only: no serializer, converter or emitter changes in any repo.**

## Why

Five record classes — `health:LabResultRecord`, `ConditionRecord`, `AllergyRecord`, `ImmunizationRecord`, `FamilyHistoryRecord` — were undefined. Undefined means no SHACL shape targeted them, which means validating a lab result, condition, allergy, immunization or family-history record ran **zero constraints and returned PASS**. The same was true of the pod export manifest, which is the first thing a consuming agent reads and the thing it trusts to decide whether an export is complete.

The concrete cost: a FHIR bundle carrying two same-day glucose readings (fasting 95, post-prandial 310 — an entirely routine pairing) can produce one subject asserting both `health:resultValue "95"` and `health:resultValue "310"`. `cascade validate` returned PASS on that, and a query then reports `"health:resultValue": "95, 310"`, a single string no consumer can interpret. `sh:maxCount 1` on `LabResultRecordShape` catches it at write time. That is what these shapes are for.

## What changed

| Vocabulary | Version | Change |
|---|---|---|
| `health` | 2.4 → **2.5** | 5 record classes, 40 properties, 4 sleep-quality individuals, 6 wellness container classes, namespace-boundary note |
| `health.shapes` | 1.1 → **1.2** | 8 new node shapes |
| `clinical` | 1.12 → **1.13** | 4 classes deprecated (not removed), 2 enum gaps documented, 1 missing shape added |
| `core` | 3.3 → **3.4** | 32 manifest terms defined on DCAT/VoID, 3 new shapes |

Constraint sets are **lifted** from the corresponding `clinical:*` shapes, not invented, then checked against FHIR R4. Where FHIR names a required value set the `sh:in` list is that value set verbatim (`AllergyIntoleranceCategory`, `AllergyIntoleranceSeverity`, `ConditionClinicalStatusCodes`, `ImmunizationStatusCodes`). `sh:Violation` on required fields: a Warning on a required field reproduces the vacuous PASS being fixed, with extra steps.

`cascade:ExportManifest` is modelled on [DCAT 3](https://www.w3.org/TR/vocab-dcat-3/) `dcat:Dataset`; `cascade:RecordSummary` on [VoID](https://www.w3.org/TR/void/) `void:Dataset` with counts as `rdfs:subPropertyOf void:entities` paired with the `void:class` each counts. `cascade:InteractionScenario` is kept as genuinely novel — no ratified vocabulary models cross-provenance correlation. Day-count properties are deliberately **not** `void:entities` subproperties: they count days, not entities, and conflating the two would make the VoID reading wrong.

## Subclass coverage is explicit, not inferred — read this before adding a class

SHACL resolves `sh:targetClass` over SHACL-instances in the **data graph**. An `rdfs:subClassOf` axiom that lives only in an ontology file does **not** expand a shape's target set. Declaring a class a subclass of a shaped class therefore gives it **no constraints at all**, and nothing reports the difference.

Measured on the stack the reference validator uses (`n3` + `rdf-validate-shacl`):

| axiom location | fires? |
|---|---|
| shapes/ontology graph only | **no** |
| data graph | yes |
| no axiom at all (control) | no |

Rows 1 and 3 are indistinguishable. So the six wellness containers are named as **explicit** `sh:targetClass` values on `HealthProfileShape`, and the `rdfs:subClassOf` axioms carry only the ontological meaning (they make the `rdfs:domain health:HealthProfile` on the eight history properties true instead of contradicted). **Anyone adding a seventh container must add its target too, or it silently inherits nothing.**

The suite asserts generally that no class anywhere relies on subclass inference for coverage. That assertion **found a real pre-existing hole**: `clinical:ConsultationNote` was the only one of six `clinical:ClinicalDocument` subclasses without an explicit target, so consultation notes validated vacuously while all five siblings were checked. Fixed here. Behaviour change: a consultation note missing `importedAt`, `sourceEHR` or `fhirResourceId` passed before and fails now.

## Measurements

Reference patient pod, 19 files:

| | before | after |
|---|---|---|
| files PASS | 19 of 19 (exit 0) | 19 of 19 (exit 0) |
| violations | 0 | 0 |
| typed subjects matched by some shape | 156 of 448 | **277 of 448** |
| matched by **no** shape | 292 (65%) | **171 (38%)** |
| undefined `health:` terms | 51 | **0** |
| undefined `cascade:` terms | 32 | **0** |

The pod's data is conformant; what changed is that it is now actually checked. `HealthProfileShape` carries 0 `sh:Violation` constraints (1 Warning, 10 Info), so wiring in the six containers cannot turn an existing pass into a failure — measured, not assumed.

**Existing conformance fixtures become executable.** 26 fixtures (`lab-001..007`, `cond-001..007`, `allergy-001..006`, `imm-001..003`, `fam-001..003`):

| | before | after |
|---|---|---|
| behaving as declared | 18 | **25** |
| not behaving as declared | 8 | 1 |

All 8 negative fixtures went from **passing vacuously** to being rejected by the exact constraint each was written to test (`MinCount(testName)`, `MinCount(dataProvenance)`, `MinCount(conditionName)`, `MinCount(schemaVersion)`, `MinCount(allergen)`, `MinLength(allergen)`, `MinCount(vaccineName)`, `MinCount(conditionName)`).

## Verification

Every claim is paired with a control that must produce the opposite result, because **a SHACL test against an unshaped class passes vacuously — which is the exact bug being fixed, so a conforming fixture passing proves nothing.**

- **25 single-defect mutations of real reference-pod files.** Each must be flagged by the intended constraint here *and* ignored entirely by the pre-change commit. Both halves asserted.
- **Shape-removal control.** Un-targeting each new shape must stop every violation attributed to it being reported. A shape that still catches its own mutation when removed was never the thing catching it.
- **Explicit-target proof.** For all six container types: a conforming instance passes, an instance violating exactly one constraint fails with that constraint named, and the pre-change commit flags none of them.
- **Determinism and distinctness.** Identical reports across three separately loaded shape graphs; different reports for clean vs mutated input and for two different defects, so the result is not a constant.

**Suite totals: passed=44 failed=0 skipped=1 total=45.** The skip is `FamilyHistoryRecordShape` — the reference pod contains no `FamilyHistoryRecord` instance, so it is covered by fixtures `fam-001..003` instead, not silently dropped.

## Two things reported, not fixed here

1. **`allergy-004` is a fixture defect.** It uses `"environmental"` where FHIR R4 `AllergyIntoleranceCategory` spells it `"environment"`. It is the one remaining fixture mismatch. Not edited — fixtures are out of scope for this PR and silently editing one to match a shape is how a suite stops meaning anything.
2. **The 8 negative fixtures carry an empty `expectedOutput.turtle`.** Any runner that validates `expectedOutput.turtle` validates an empty graph, which trivially conforms, so it will report all 8 as passing no matter what the shapes say. They must be serialized from `input`. Flagged for whoever builds the conformance runner.

Also worth knowing for the downstream sync: `health:DailyVitalReading` is emitted in **two** incompatible spellings — `health:value`/`health:unit`/`health:date` by one serializer, `fhir:valueQuantity`/`cascade:date` by another. `DailyVitalReadingShape` requires a date and a value through `sh:or` rather than picking a spelling and silently invalidating the other.

## Tags — NOT pushed

Tags point at unmerged content until this merges. To be run **after merge**, on the merge commit:

```
git tag vocab/health-v2.5    -m "health v2.5: clinical record classes + shapes"
git tag vocab/clinical-v1.13 -m "clinical v1.13: deprecate duplicated record classes"
git tag vocab/core-v3.4      -m "core v3.4: pod export manifest on DCAT/VoID"
git push origin vocab/health-v2.5 vocab/clinical-v1.13 vocab/core-v3.4
```

## Also in this PR

`scripts/check-downstream-versions.sh` read `VOCAB_VERSIONS` as a plain working-tree file path, so a checkout on an unmerged branch reported that branch's proposed numbers as "Canonical" and every downstream repo as drifted against a version nobody had ratified. The inverse also held: a downstream repo whose sync existed only on an unmerged branch was reported UP TO DATE. Both sides now read from the repo's integration branch, and an unmerged bump is reported as pending with a non-zero exit.

On this branch it correctly refuses to call its own bump canonical:

```
Canonical vocab versions (spec @ origin/main):
  core = 3.3   health = 2.4   clinical = 1.12

!! SPEC WORKING TREE IS AHEAD OF origin/main -- NOT YET CANONICAL
!!   branch: feat/health-v2.5-record-shapes
!!   core: working tree=3.4  origin/main=3.3
!!   health: working tree=2.5  origin/main=2.4
!!   clinical: working tree=1.13  origin/main=1.12
```

`scripts/test-check-downstream-versions.sh` covers it: **20 assertions, 5 of which replay each scenario against the previous version of the checker read out of git history and require it to produce the wrong answer**, so the suite cannot pass vacuously. passed=20 failed=0 skipped=0 total=20.

## Downstream

Six repos are still at `clinical=1.9` and absorb these three bumps in the existing pending batch; the ledger row is updated. `cascade-cli`'s `sync-shapes-from-spec.sh` syncs full ontologies for `core clinical coverage` only, so `src/shapes/health.ttl` has never been synced by it — that needs fixing in the same pass or these shapes will not reach the CLI.

Note that `FamilyHistoryRecordShape` is correct but its records currently route to a passthrough file rather than their own bucket. That is a separate routing defect, not an oversight in this PR.
