### PR TITLE
Validation Profile 1.0: state and enforce the entailment regime Cascade shapes assume

### DIFF
--- a/.github/workflows/shapes.yml
+++ b/.github/workflows/shapes.yml
@@ -1,0 +1,40 @@
+name: shapes
+
+# Enforces the Validation Profile (validation/index.md) on every change to a
+# vocabulary or its shapes: no shape published here may depend on RDFS
+# entailment to reach the classes it constrains. Without this job the rule is
+# only a document, and the gap it forbids has already been authored twice.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'ontologies/**'
+      - 'scripts/check-shape-targets.py'
+      - 'scripts/test-check-shape-targets.sh'
+      - 'scripts/requirements.txt'
+      - '.github/workflows/shapes.yml'
+  workflow_dispatch:
+
+jobs:
+  entailment-independence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: python3 -m pip install -r scripts/requirements.txt
+
+      # The regression suite runs the check against the repository AND against
+      # scratch copies with known violations reintroduced, so a check that has
+      # stopped being able to fail is caught here rather than in a consumer.
+      - name: Regression suite (check + negative controls)
+        run: sh scripts/test-check-shape-targets.sh
+
+      - name: Entailment-independence check
+        run: python3 scripts/check-shape-targets.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Format: each entry is one milestone, dated, with a short prose summary and point
 
 ---
 
+## 2026-08-03: Validation Profile 1.0 (the entailment regime, stated and enforced)
+
+New normative document `validation/index.md`, plus the check that holds this repository to it. No released vocabulary changes; nothing in `VOCAB_VERSIONS` moves.
+
+**The problem.** SHACL is a validation language, not a validation configuration. [SHACL 2.1.3.1](https://www.w3.org/TR/shacl/#targetClass) resolves `sh:targetClass` over SHACL-instances in the DATA graph, and Cascade pod records carry `rdf:type` triples but no schema axioms. A subclass axiom declared in an ontology file therefore confers no shape coverage on the subclass. A validator that merges ontologies into the data graph before validating sees the opposite, and both readings conform to SHACL. The same file could be valid under one implementation and invalid under another with neither doing anything wrong.
+
+**The rule.** Cascade shapes are entailment-independent. Every class a shape means to constrain carries an explicit `sh:targetClass`; constraint inheritance is stated with `sh:node` or a shared target list rather than inferred; `sh:class` value constraints enumerate the acceptable subclasses. A conforming validator MUST reach a correct verdict with no inferencing, MAY perform entailment as an extension, and MUST get the same verdict either way. A verdict difference between an entailing and a non-entailing validator is a defect in the shapes, not a validator configuration question. A conformance suite must be able to reproduce every fixture's expected outcome with no pre-validation merge. The rejected alternative, mandating an ontology merge, is argued in `validation/index.md` §4: it moves correctness into every consumer's configuration and is unenforceable in a library embedded in someone else's application.
+
+`rdfs:subClassOf` is unaffected and still required for modelling. It is what makes `rdfs:domain` / `rdfs:range` true, and it is what the check reads to work out which classes need an explicit target. It is simply not a validation mechanism.
+
+**The enforcement.** `scripts/check-shape-targets.py` evaluates three assertions over every ontology and shapes file here: target closure (T), constraint-set equivalence (I), and value-class closure (C). It reports how many cases each examined and fails if any examined none, because an assertion with nothing to inspect has established nothing. `scripts/test-check-shape-targets.sh` is its regression suite: every assertion is paired with a scratch copy of the repository carrying a deliberately reintroduced violation that the check must catch and name. New CI job `shapes` runs both on every PR touching `ontologies/`. This is the first automated test of this repository's own shapes.
+
+**Found on the first run, and fixed here:** genomics v1-draft.0.5. `genomics:CopyNumberVariantShape` claimed in its comment to inherit `VariantShape` transitively and did not, so copy number variants were never checked for `genomics:dataQualityTier` (the value the `D-QUALITY-TIER` safety constraint on `VariantInterpretation` is evaluated against) or for carrying a stable identifier. Measured across both engines: the same fixture was reported conforming by a non-entailing validator and non-conforming with two Violation results by an entailing one. Fixed with an explicit `sh:node`, after which both engines agree. `HaplotypeShape`'s `hasComponent` `sh:class` was widened to enumerate `CopyNumberVariant`. See `ontologies/genomics/CHANGELOG.md`.
+
+The released vocabularies (`core`, `health`, `clinical`, `coverage`, `checkup`, `pots`) already satisfy all three assertions and are unchanged. No tag; the Validation Profile carries its own version, as `serialization/index.md` does, and `VOCAB_VERSIONS` records vocabulary versions rather than profile versions.
+
+---
+
 ## 2026-07-16: clinical v1.9 to v1.10 (graph edge vocabulary)
 
 Gives the importer traversable RDF for the relationships EHR sources carry but the pod has been flattening. Four authored changes to the released `clinical` vocabulary (slice V1 of the graph-retrieval sequenced plan; root backlog 3.12 and 3.11(d); blocks importer slice R3):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,28 @@ Example relationship:
 - `clinical.ttl` defines `clinical:MedicationRecord` as an OWL class with properties
 - `clinical.shapes.ttl` defines `clinical:MedicationShape` targeting `health:MedicationRecord` with constraints like required fields, datatypes, and value enumerations
 
+### Shapes MUST be entailment-independent
+
+Read `validation/index.md` before authoring or editing a shape. The rule in one line: **a shape never reaches a class through `rdfs:subClassOf`.**
+
+SHACL resolves class membership over the DATA graph. Pod records carry `rdf:type` triples and no schema axioms, so a subclass axiom that lives in an ontology file confers nothing at validation time. A validator that merges the ontology first sees the opposite, which means the same file can be valid under one implementation and invalid under another.
+
+Three consequences when you touch a shapes file:
+
+1. Every class you mean to constrain gets its own `sh:targetClass`. Declaring `Child rdfs:subClassOf Parent` does not put `Child` under `ParentShape`.
+2. Constraint inheritance is written, not inferred: either one shape names parent and children in `sh:targetClass`, or the child's shape names the parent's shape with `sh:node`.
+3. `sh:class` works the same way. `sh:class Parent` rejects a value typed `Child`; enumerate the acceptable subclasses with `sh:or`.
+
+This has been authored wrong twice, in two different vocabularies, both times with a comment claiming an inheritance the shape did not have. Run the check rather than trusting the comment:
+
+```sh
+python3 -m pip install -r scripts/requirements.txt
+python3 scripts/check-shape-targets.py          # the rule
+sh scripts/test-check-shape-targets.sh          # the rule's own regression suite
+```
+
+`rdfs:subClassOf` itself stays. It is what makes `rdfs:domain` / `rdfs:range` true and what the check uses to work out which classes need an explicit target. It is simply not a validation mechanism.
+
 ### Version Bumping
 
 When modifying an ontology:
@@ -68,6 +90,7 @@ Before committing any change to an ontology (`.ttl`) file, you MUST:
 - [ ] Update the corresponding `.shapes.ttl` if new classes/properties were added
 - [ ] Update JSON-LD context (`contexts/v1/{name}.jsonld`) if new terms need `@type` / `@id` mappings
 - [ ] Update `VOCAB_VERSIONS` file for this vocabulary — stage it with `git add VOCAB_VERSIONS`
+- [ ] Run `python3 scripts/check-shape-targets.py` and get exit 0 (the `shapes` CI job runs it, and its regression suite, on every PR touching `ontologies/`)
 - [ ] Tag the commit: `git tag vocab/{name}-v{X.Y}` after committing
 
 After committing, complete the downstream update sequence (in order):

--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -351,6 +351,51 @@ above — those repos are still at `clinical=1.9`):**
 
 ---
 
+## Pending batch — Validation Profile 1.0 + genomics v1-draft.0.5 (authored 2026-08-03)
+
+**No released vocabulary changed and no version in `VOCAB_VERSIONS` moved**, so
+the drift checker will keep reporting every repo up to date. The propagation
+below is nonetheless real: it changes what two tools are permitted to do, and it
+tightens one draft shape that `cascade-cli` embeds a copy of.
+
+**What was authored:** `validation/index.md` (Validation Profile 1.0), the
+normative statement of the entailment regime these shapes assume;
+`scripts/check-shape-targets.py` and `scripts/test-check-shape-targets.sh`
+enforcing it; CI job `shapes`; genomics v1-draft.0.5, the two shape corrections
+the check found on its first run. See `CHANGELOG.md` for the rule.
+
+**Synced NOW (not batched):**
+
+- [x] `spec/` — authored (this repo). No `VOCAB_VERSIONS` change: drafts are
+      unrowed per D-PATH and no released vocabulary moved.
+- [ ] `cascade-cli` — re-sync `src/shapes/genomics.shapes.ttl` so the embedded
+      copy carries the `sh:node` and the widened `sh:class`. Until then
+      `cascade validate` will not check copy number variants for
+      `genomics:dataQualityTier`.
+
+**Batched:**
+
+- [ ] `conformance` — the runner passes the `rdfs:subClassOf` axioms as
+      `ont_graph`, which entails more than the implementations it certifies, so
+      a fixture can pass the gate and fail in a strict validator. Per profile
+      rule V5 every fixture's expected outcome must be reproducible with no
+      pre-validation merge. Re-run with the merge removed and confirm no fixture
+      outcome changes; any that does was testing the runner's configuration
+      rather than the implementation's behaviour. Cite `validation/index.md`
+      wherever the inferencing setting lives.
+- [ ] `cascade-cli` — cite `validation/index.md` at the shapes-loading site, so
+      the (correct, conformant) decision not to entail is recorded as a decision
+      rather than an accident. Consider the profile's §6 assertion for vendored
+      shapes: every `sh:targetClass` in the bundled copy must resolve to a class
+      in the bundled vocabulary.
+- [ ] `cascadeprotocol.org` — publish `validation/index.md`; add it to
+      `scripts/sync-from-spec.sh`, which currently copies ontologies and
+      contexts only.
+- [ ] `sdk-typescript` / `sdk-python` / `cascade-agent` — no change. Neither SDK
+      validates, and no vocabulary term moved.
+
+---
+
 ## Open items
 
 ### 1. `clinical:sourceSystemOID` (planned) — NOT yet authored, deferred

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ spec/
   serialization/
     turtle-rules.md         # Turtle serialization conventions
     pod-structure.md        # Pod directory layout spec
+  validation/
+    index.md                # Validation Profile: the entailment regime shapes assume
   contexts/
     cascade-v1.jsonld       # JSON-LD context for all vocabularies
   CHANGELOG.md
@@ -76,6 +78,8 @@ Validate data against shapes using the [Cascade CLI](https://github.com/the-casc
 ```bash
 cascade validate record.ttl
 ```
+
+**Shapes are entailment-independent.** SHACL resolves class membership over the data graph, so a shape that reached a class only through an `rdfs:subClassOf` axiom would fire in a validator that merges ontologies and stay silent in one that does not, so the same file would be valid under one implementation and invalid under another. Every class these shapes constrain therefore carries an explicit `sh:targetClass`, and constraint inheritance is stated with `sh:node` rather than inferred. [`validation/index.md`](validation/index.md) states the rule normatively; `scripts/check-shape-targets.py` enforces it on every change.
 
 ## Namespace Prefixes
 

--- a/ontologies/genomics/CHANGELOG.md
+++ b/ontologies/genomics/CHANGELOG.md
@@ -5,6 +5,44 @@ namespace is `https://ns.cascadeprotocol.org/genomics/v1#`. Pre-stable drafts
 (`v1-draft`) are not registered in `spec/VOCAB_VERSIONS` per D-PATH; they land
 there at v1.0 graduation.
 
+## v1-draft.0.5 - 2026-08-03
+
+Two SHACL corrections. No vocabulary additions; shapes only. Both were found by
+`scripts/check-shape-targets.py`, the new check that enforces the Validation
+Profile (`validation/index.md`), on its first run against this repository.
+
+### `CopyNumberVariantShape` did not actually inherit `VariantShape`
+
+`genomics:CopyNumberVariant` is `rdfs:subClassOf genomics:Variant`, and the
+shape's own comment stated that `VariantShape`'s constraints "apply
+transitively". They did not. SHACL resolves `sh:targetClass` over
+SHACL-instances in the DATA graph, and pod records carry `rdf:type` triples
+rather than schema axioms, so a subclass axiom declared in `genomics.ttl`
+reaches nothing at validation time.
+
+The measured effect: a copy number variant carrying no
+`genomics:dataQualityTier` and no stable identifier was reported **conforming**
+by a validator that performs no entailment, and **non-conforming with two
+Violation-severity results** by one that merges the subclass axioms. The
+missing tier matters beyond bookkeeping, because the `D-QUALITY-TIER` safety
+constraint on `VariantInterpretation` is evaluated against it.
+
+`genomics:CopyNumberVariantShape` now carries `sh:node genomics:VariantShape`,
+which every conforming validator applies whether or not it entails. Both
+engines now agree that the same fixture fails. This is a **tightening**: CNV
+records that were silently unchecked for gene symbol, data-quality tier and
+stable identifier are now checked for them.
+
+### `HaplotypeShape` `hasComponent` excluded `CopyNumberVariant`
+
+`sh:class` is resolved the same way as `sh:targetClass`, so
+`sh:class genomics:Variant` accepted only components explicitly typed
+`genomics:Variant`. A component typed `genomics:CopyNumberVariant` was rejected
+by a non-entailing validator and accepted by an entailing one. The acceptable
+classes are now enumerated with `sh:or`, matching the idiom already used by
+`VariantInterpretationShape.variantInterpreted`. This is a **relaxation** for
+strict validators: CNV components that were reported as warnings now pass.
+
 ## v1-draft.0.4 - 2026-06-16
 
 Index-patient phenotype capture (for Cascade Workbench).

--- a/ontologies/genomics/v1-draft/genomics.shapes.ttl
+++ b/ontologies/genomics/v1-draft/genomics.shapes.ttl
@@ -473,12 +473,22 @@ genomics:HaplotypeShape a sh:NodeShape ;
     ] ;
 
     # WARNING: hasComponent recommended for full provenance.
+    #
+    # The acceptable component classes are ENUMERATED rather than left to
+    # subclass inference. sh:class is resolved over SHACL-instances in the DATA
+    # graph, so `sh:class genomics:Variant` alone accepts only nodes explicitly
+    # typed genomics:Variant. A component typed genomics:CopyNumberVariant
+    # would be rejected by a validator that performs no entailment and accepted
+    # by one that does. See validation/index.md, rule S3.
     sh:property [
         sh:path genomics:hasComponent ;
-        sh:class genomics:Variant ;
+        sh:or (
+            [ sh:class genomics:Variant ]
+            [ sh:class genomics:CopyNumberVariant ]
+        ) ;
         sh:severity sh:Warning ;
         sh:name "Component Variants"@en ;
-        sh:message "genomics:hasComponent is recommended; absence prevents downstream tools from auditing which constituent variants define this star allele"@en
+        sh:message "genomics:hasComponent is recommended; absence prevents downstream tools from auditing which constituent variants define this star allele. When present, each component must be a genomics:Variant or genomics:CopyNumberVariant."@en
     ] .
 
 # ============================================================================
@@ -526,14 +536,26 @@ genomics:DiplotypeShape a sh:NodeShape ;
 # ============================================================================
 # Shape 5: Copy Number Variant
 # ============================================================================
-# Note: CopyNumberVariant rdfs:subClassOf genomics:Variant in the ontology,
-# so VariantShape constraints apply transitively (geneSymbol, dataQualityTier,
-# at-least-one-stable-ID). This shape adds CNV-specific requirements.
+# CopyNumberVariant is rdfs:subClassOf genomics:Variant in the ontology, but a
+# subclass axiom does NOT carry VariantShape's constraints across. SHACL
+# resolves sh:targetClass over SHACL-instances in the DATA graph, and pod
+# records carry rdf:type triples, not schema axioms, so an axiom that lives
+# only in genomics.ttl reaches nothing at validation time. Until v1-draft.0.5
+# this shape asserted the inheritance in its comment and did not implement it,
+# with the result that CNVs were never checked for genomics:dataQualityTier
+# (a Violation-severity constraint the D-QUALITY-TIER safety rule on
+# VariantInterpretation depends on) or for carrying a stable identifier.
+# The inheritance is now stated explicitly with sh:node, which every conforming
+# validator applies whether or not it entails. See validation/index.md, rule S2.
 
 genomics:CopyNumberVariantShape a sh:NodeShape ;
     sh:targetClass genomics:CopyNumberVariant ;
     rdfs:label "Copy Number Variant Shape"@en ;
-    rdfs:comment "Validation constraints specific to genomics:CopyNumberVariant. Inherits VariantShape constraints (geneSymbol, dataQualityTier, at least one stable ID) via rdfs:subClassOf and adds the CNV-specific requirements: integer copy number, interval coordinates with reference."@en ;
+    rdfs:comment "Validation constraints specific to genomics:CopyNumberVariant. Applies VariantShape's constraints (geneSymbol, dataQualityTier, at least one stable ID) explicitly via sh:node, and adds the CNV-specific requirements: integer copy number, interval coordinates with reference."@en ;
+
+    # Applies every VariantShape constraint to this focus node. Explicit, so the
+    # constraint set does not depend on the validator performing entailment.
+    sh:node genomics:VariantShape ;
 
     # VIOLATION: copyNumber required, integer.
     sh:property [

--- a/scripts/check-shape-targets.py
+++ b/scripts/check-shape-targets.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""check-shape-targets.py: enforce the entailment-independence rule on this
+repository's own SHACL shapes.
+
+The rule is stated normatively in validation/index.md. In short: SHACL resolves
+class membership over the DATA graph, so a validator that performs no RDFS
+entailment sees only the rdf:type triples a record actually carries. A shape
+that reaches a class only through an rdfs:subClassOf axiom in an ontology file
+therefore fires in an entailing validator and stays silent in a strictly
+conforming one. Two implementations then disagree about whether the same file
+is valid.
+
+These shapes must behave identically in both. This script proves it by
+construction, over three assertions:
+
+  T  TARGET CLOSURE
+     If a class has a proper superclass that some shape targets, the class
+     itself must be targeted by some shape. Otherwise an entailing validator
+     checks its instances and a non-entailing one checks nothing.
+
+  I  CONSTRAINT-SET EQUIVALENCE
+     A class whose superclass is targeted must reach that superclass's
+     constraints explicitly: either the same shape targets both, or the
+     subclass's shape names the superclass's shape with sh:node. Otherwise the
+     two engines apply different constraint sets to the same node.
+
+  C  VALUE-CLASS CLOSURE
+     sh:class is resolved the same way as sh:targetClass. The set of classes
+     accepted at one constraint site must be closed under rdfs:subClassOf, so
+     enumerate the acceptable subclasses (sh:or) rather than relying on the
+     superclass name to cover them.
+
+Exit status: 0 if every assertion holds, 1 if any fails or if the run examined
+nothing (a check that found no material to inspect has proven nothing and is
+reported as a failure, not a pass).
+
+Usage:  python3 scripts/check-shape-targets.py [spec-root]
+Requires: rdflib (see scripts/requirements.txt)
+"""
+
+import glob
+import os
+import sys
+
+try:
+    from rdflib import Graph, RDF, RDFS, OWL, URIRef, Namespace
+except ImportError:  # pragma: no cover - environment guard
+    sys.stderr.write(
+        "ERROR: rdflib is not installed. This check parses Turtle and cannot\n"
+        "       degrade to a text scan without becoming unsound.\n"
+        "       Install it with:  python3 -m pip install -r scripts/requirements.txt\n"
+    )
+    sys.exit(2)
+
+SH = Namespace("http://www.w3.org/ns/shacl#")
+CASCADE_NS_PREFIX = "https://ns.cascadeprotocol.org/"
+
+ONTOLOGY_GLOB = "ontologies/*/v1*/*.ttl"
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def load(root):
+    """Parse every ontology and shapes file under root into two graphs."""
+    onto, shapes = Graph(), Graph()
+    files = sorted(glob.glob(os.path.join(root, ONTOLOGY_GLOB)))
+    if not files:
+        sys.stderr.write(
+            "ERROR: no ontology files matched %s under %s\n" % (ONTOLOGY_GLOB, root)
+        )
+        sys.exit(2)
+    for path in files:
+        target = shapes if path.endswith(".shapes.ttl") else onto
+        target.parse(path, format="turtle")
+    return onto, shapes, files
+
+
+def qname(term):
+    """Render a Cascade term as prefix:Local, anything else as its full IRI."""
+    text = str(term)
+    if text.startswith(CASCADE_NS_PREFIX):
+        rest = text[len(CASCADE_NS_PREFIX):]
+        vocab, _, local = rest.partition("#")
+        vocab = vocab.split("/")[0]
+        prefix = "cascade" if vocab == "core" else vocab
+        return "%s:%s" % (prefix, local)
+    return "<%s>" % text
+
+
+# ---------------------------------------------------------------------------
+# Graph facts
+# ---------------------------------------------------------------------------
+
+def superclass_edges(onto):
+    """direct[c] = set of classes c is declared a direct subclass of."""
+    direct = {}
+    for sub, sup in onto.subject_objects(RDFS.subClassOf):
+        if isinstance(sub, URIRef) and isinstance(sup, URIRef):
+            direct.setdefault(sub, set()).add(sup)
+    return direct
+
+
+def proper_superclasses(cls, direct):
+    """Transitive closure of rdfs:subClassOf, excluding cls itself."""
+    seen, stack = set(), list(direct.get(cls, ()))
+    while stack:
+        node = stack.pop()
+        if node not in seen and node != cls:
+            seen.add(node)
+            stack.extend(direct.get(node, ()))
+    return seen
+
+
+def declared_classes(onto):
+    return {
+        c
+        for c in set(onto.subjects(RDF.type, OWL.Class))
+        | set(onto.subjects(RDF.type, RDFS.Class))
+        if isinstance(c, URIRef)
+    }
+
+
+def target_index(shapes):
+    """by_class[C] = set of shapes that give C an explicit class target.
+
+    Covers sh:targetClass and SHACL's implicit class targets (§2.1.3.3): a
+    shape that is itself declared an rdfs:Class or owl:Class targets its own
+    instances. Both are explicit in the sense that matters here, because both
+    are stated in the shapes graph rather than reached by inference.
+    """
+    by_class = {}
+    for shape, cls in shapes.subject_objects(SH.targetClass):
+        if isinstance(cls, URIRef):
+            by_class.setdefault(cls, set()).add(shape)
+    for shape in set(shapes.subjects(RDF.type, SH.NodeShape)):
+        if not isinstance(shape, URIRef):
+            continue
+        if (shape, RDF.type, RDFS.Class) in shapes or (shape, RDF.type, OWL.Class) in shapes:
+            by_class.setdefault(shape, set()).add(shape)
+    return by_class
+
+
+def constraint_sites(shapes):
+    """Yield (holder, {sh:class values reachable at that site}).
+
+    A "site" is one constraint holder: a node shape, or the value of one
+    sh:property. sh:or / sh:and / sh:xone list members belong to the same site,
+    because a value satisfying any listed alternative satisfies the site.
+    sh:not is skipped: negation inverts the argument, so downward closure does
+    not apply to it.
+    """
+    holders = set(shapes.subjects(SH.property, None))
+    holders |= set(shapes.objects(None, SH.property))
+    for holder in holders:
+        values = set()
+        seen = set()
+        stack = [holder]
+        while stack:
+            node = stack.pop()
+            if node in seen:
+                continue
+            seen.add(node)
+            for cls in shapes.objects(node, SH["class"]):
+                if isinstance(cls, URIRef):
+                    values.add(cls)
+            for combinator in (SH["or"], SH["and"], SH.xone):
+                for lst in shapes.objects(node, combinator):
+                    stack.extend(shapes.items(lst))
+        if values:
+            yield holder, values
+
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+
+def assert_target_closure(classes, direct, targets):
+    """T: a class under a targeted superclass must itself be targeted."""
+    examined, findings = 0, []
+    for cls in sorted(classes, key=str):
+        supers = proper_superclasses(cls, direct)
+        targeted_supers = supers & set(targets)
+        if not targeted_supers:
+            continue
+        examined += 1
+        if cls not in targets:
+            findings.append(
+                "%s has no sh:targetClass but inherits from shaped %s"
+                % (qname(cls), ", ".join(sorted(qname(s) for s in targeted_supers)))
+            )
+    return examined, findings
+
+
+def assert_constraint_equivalence(classes, direct, targets, shapes):
+    """I: the constraint set must not depend on the target set expanding."""
+    examined, findings = 0, []
+    for cls in sorted(classes, key=str):
+        if cls not in targets:
+            continue
+        for sup in sorted(proper_superclasses(cls, direct), key=str):
+            if sup not in targets:
+                continue
+            examined += 1
+            super_shapes = targets[sup]
+            satisfied = False
+            for shape in targets[cls]:
+                if shape in super_shapes:
+                    satisfied = True  # one shape targets both
+                    break
+                referenced = set(shapes.objects(shape, SH.node))
+                if referenced & super_shapes:
+                    satisfied = True  # explicit sh:node reference
+                    break
+            if not satisfied:
+                findings.append(
+                    "%s is targeted, and so is its superclass %s, but no shape "
+                    "targeting %s reaches %s's constraints via sh:node "
+                    "(entailing validators would apply them, others would not)"
+                    % (qname(cls), qname(sup), qname(cls), qname(sup))
+                )
+    return examined, findings
+
+
+def assert_value_class_closure(direct, shapes):
+    """C: the classes accepted at one sh:class site must be downward closed."""
+    subclasses = {}
+    for sub, sups in direct.items():
+        for sup in sups:
+            subclasses.setdefault(sup, set()).add(sub)
+
+    def descendants(cls):
+        out, stack = set(), list(subclasses.get(cls, ()))
+        while stack:
+            node = stack.pop()
+            if node not in out:
+                out.add(node)
+                stack.extend(subclasses.get(node, ()))
+        return out
+
+    examined, findings = 0, []
+    for holder, accepted in constraint_sites(shapes):
+        examined += 1
+        missing = set()
+        for cls in accepted:
+            missing |= descendants(cls) - accepted
+        if missing:
+            paths = sorted(qname(p) for p in shapes.objects(holder, SH.path))
+            where = paths[0] if paths else "(node shape)"
+            findings.append(
+                "sh:class site on %s accepts %s but not its subclass(es) %s "
+                "(enumerate them with sh:or)"
+                % (
+                    where,
+                    ", ".join(sorted(qname(a) for a in accepted)),
+                    ", ".join(sorted(qname(m) for m in missing)),
+                )
+            )
+    return examined, findings
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def main():
+    root = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), ".."
+    )
+    root = os.path.abspath(root)
+
+    onto, shapes, files = load(root)
+    classes = declared_classes(onto)
+    direct = superclass_edges(onto)
+    targets = target_index(shapes)
+
+    print("Entailment-independence check (see validation/index.md)")
+    print("  root:              %s" % root)
+    print("  files parsed:      %d" % len(files))
+    print("  classes declared:  %d" % len(classes))
+    print("  classes targeted:  %d" % len(targets))
+    print("  subclass edges:    %d" % sum(len(v) for v in direct.values()))
+    print()
+
+    results = [
+        ("T  target closure", assert_target_closure(classes, direct, targets)),
+        (
+            "I  constraint-set equivalence",
+            assert_constraint_equivalence(classes, direct, targets, shapes),
+        ),
+        ("C  value-class closure", assert_value_class_closure(direct, shapes)),
+    ]
+
+    failed = 0
+    empty = 0
+    for name, (examined, findings) in results:
+        if examined == 0:
+            empty += 1
+            print("EMPTY %s: examined 0 cases; this proves nothing" % name)
+            continue
+        if findings:
+            failed += 1
+            print("FAIL  %s: %d finding(s) over %d case(s) examined"
+                  % (name, len(findings), examined))
+            for finding in findings:
+                print("        %s" % finding)
+        else:
+            print("PASS  %s: %d case(s) examined" % (name, examined))
+
+    print()
+    if empty:
+        print("RESULT: FAIL, %d assertion(s) examined nothing." % empty)
+        print("A check with no material to inspect has not verified anything.")
+        return 1
+    if failed:
+        print("RESULT: FAIL, %d of %d assertion(s) failed." % (failed, len(results)))
+        print("Shapes must behave identically in an entailing and a non-entailing")
+        print("validator. See validation/index.md for the rule and the fix.")
+        return 1
+    print("RESULT: PASS, %d of %d assertion(s) hold." % (len(results), len(results)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,7 @@
+# Python dependencies for this repository's own checks.
+#
+# Pinned to the same rdflib the conformance suite installs, so a Turtle file
+# that parses here parses there. Nothing in spec/ runs a SHACL validator
+# (check-shape-targets.py reasons over graph structure only), so pyshacl is
+# deliberately not a dependency of this repository.
+rdflib==7.6.0

--- a/scripts/test-check-shape-targets.sh
+++ b/scripts/test-check-shape-targets.sh
@@ -1,0 +1,308 @@
+#!/bin/sh
+# test-check-shape-targets.sh
+#
+# Regression suite for check-shape-targets.py.
+#
+# The defect under test: a SHACL shape can reach a class only through an
+# rdfs:subClassOf axiom that lives in an ontology file. Validators that merge
+# that axiom into the data graph then fire the shape; validators that follow
+# SHACL literally do not. The same file is valid under one implementation and
+# invalid under the other, and neither is wrong. See validation/index.md.
+#
+# Every assertion below is paired with a NEGATIVE CONTROL: a scratch copy of
+# the repository's ontologies with one entailment dependency deliberately
+# reintroduced, which the check must catch and must name. A check that has
+# only ever been observed passing is not evidence that it can fail.
+#
+# The suite also proves the check is not vacuous: it is run against a corpus
+# with no subclass relationships at all, where it must report FAIL because it
+# examined nothing, not PASS because it found nothing to complain about.
+#
+# Usage: ./scripts/test-check-shape-targets.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SPEC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK="$SCRIPT_DIR/check-shape-targets.py"
+PYTHON="${PYTHON:-python3}"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+pass() { PASSED=$((PASSED + 1)); echo "  PASS  $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "  FAIL  $1"; echo "        $2"; }
+skip() { SKIPPED=$((SKIPPED + 1)); echo "  SKIP  $1  ($2)"; }
+
+# A missing parser is a hard failure, never a skip. Skipping the whole suite
+# because a dependency is absent reports green while testing nothing, which is
+# the exact class of defect this file guards against.
+if ! "$PYTHON" -c "import rdflib" 2>/dev/null; then
+  echo "ERROR: $PYTHON cannot import rdflib, so this suite would test nothing."
+  echo "       Install it:  $PYTHON -m pip install -r scripts/requirements.txt"
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+CLIN="ontologies/clinical/v1/clinical.shapes.ttl"
+GEN="ontologies/genomics/v1-draft/genomics.shapes.ttl"
+
+# Build a scratch copy of the ontology tree that a case can mutate freely.
+scratch() {
+  dir="$WORK/$1"
+  mkdir -p "$dir"
+  cp -R "$SPEC_ROOT/ontologies" "$dir/ontologies"
+  echo "$dir"
+}
+
+echo ""
+echo "=========================================================="
+echo "  check-shape-targets.py regression suite"
+echo "  spec root: $SPEC_ROOT"
+echo "=========================================================="
+
+# ---------------------------------------------------------------------------
+# 1. Positive control: the repository as committed must pass.
+# ---------------------------------------------------------------------------
+echo ""
+echo "1. Positive control: the repository's own shapes"
+
+OUT="$("$PYTHON" "$CHECK" "$SPEC_ROOT" 2>&1)"
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+  pass "committed shapes satisfy every assertion (exit 0)"
+else
+  fail "committed shapes do not pass the check (exit $STATUS)" "$OUT"
+fi
+
+if echo "$OUT" | grep -q "RESULT: PASS"; then
+  pass "reports RESULT: PASS"
+else
+  fail "did not report RESULT: PASS" "$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Non-vacuity: every assertion must have examined something.
+# ---------------------------------------------------------------------------
+echo ""
+echo "2. Non-vacuity: assertions must examine a non-zero number of cases"
+
+for LETTER in T I C; do
+  LINE="$(echo "$OUT" | grep "^PASS  $LETTER ")"
+  COUNT="$(echo "$LINE" | sed -n 's/.*: \([0-9][0-9]*\) case.*/\1/p')"
+  if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ] 2>/dev/null; then
+    pass "assertion $LETTER examined $COUNT case(s)"
+  else
+    fail "assertion $LETTER reported no case count" "$LINE"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. Negative control for T (target closure).
+#
+#    clinical:ConsultationNote is one of six rdfs:subClassOf
+#    clinical:ClinicalDocument. Delete its explicit sh:targetClass and it goes
+#    back to being reachable only by subclass inference, validating vacuously
+#    in a strict validator while its five siblings are checked. The check must
+#    catch that and must name the class.
+# ---------------------------------------------------------------------------
+echo ""
+echo "3. Negative control T: remove clinical:ConsultationNote's explicit target"
+
+DIR="$(scratch t)"
+grep -v 'sh:targetClass clinical:ConsultationNote' "$SPEC_ROOT/$CLIN" > "$DIR/$CLIN.tmp"
+mv "$DIR/$CLIN.tmp" "$DIR/$CLIN"
+
+if [ "$(grep -c 'sh:targetClass clinical:ConsultationNote' "$DIR/$CLIN")" -eq 0 ] &&
+   [ "$(grep -c 'sh:targetClass clinical:ConsultationNote' "$SPEC_ROOT/$CLIN")" -eq 1 ]; then
+  pass "mutation applied (1 target line removed)"
+else
+  fail "mutation did not apply as expected" "check the sh:targetClass line in $CLIN"
+fi
+
+OUT_T="$("$PYTHON" "$CHECK" "$DIR" 2>&1)"
+STATUS_T=$?
+if [ $STATUS_T -ne 0 ]; then
+  pass "check fails against the reintroduced violation (exit $STATUS_T)"
+else
+  fail "check PASSED against a known violation" "$OUT_T"
+fi
+
+if echo "$OUT_T" | grep -q "^FAIL  T "; then
+  pass "assertion T is the one that fails"
+else
+  fail "assertion T did not fail" "$OUT_T"
+fi
+
+if echo "$OUT_T" | grep -q "clinical:ConsultationNote"; then
+  pass "names clinical:ConsultationNote in the finding"
+else
+  fail "did not name the offending class" "$OUT_T"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Negative control for I (constraint-set equivalence).
+#
+#    clinical:ProgressNoteShape carries its parent's constraints with
+#    sh:node clinical:ClinicalDocumentShape. Remove that line and the shape
+#    still targets ProgressNote, so assertion T stays green, but an entailing
+#    validator would apply ClinicalDocumentShape to the node and a strict one
+#    would not. Only assertion I can see this.
+# ---------------------------------------------------------------------------
+echo ""
+echo "4. Negative control I: remove ProgressNoteShape's explicit sh:node"
+
+DIR="$(scratch i)"
+awk '
+  /^clinical:ProgressNoteShape/ { inpn = 1 }
+  inpn && /sh:node clinical:ClinicalDocumentShape/ { inpn = 0; next }
+  { print }
+' "$SPEC_ROOT/$CLIN" > "$DIR/$CLIN.tmp"
+mv "$DIR/$CLIN.tmp" "$DIR/$CLIN"
+
+BEFORE_N="$(grep -c 'sh:node clinical:ClinicalDocumentShape' "$SPEC_ROOT/$CLIN")"
+AFTER_N="$(grep -c 'sh:node clinical:ClinicalDocumentShape' "$DIR/$CLIN")"
+if [ "$AFTER_N" -eq "$((BEFORE_N - 1))" ]; then
+  pass "mutation applied (sh:node lines $BEFORE_N -> $AFTER_N)"
+else
+  fail "mutation did not remove exactly one sh:node line" "$BEFORE_N -> $AFTER_N"
+fi
+
+OUT_I="$("$PYTHON" "$CHECK" "$DIR" 2>&1)"
+STATUS_I=$?
+if [ $STATUS_I -ne 0 ]; then
+  pass "check fails against the reintroduced violation (exit $STATUS_I)"
+else
+  fail "check PASSED against a known violation" "$OUT_I"
+fi
+
+if echo "$OUT_I" | grep -q "^FAIL  I "; then
+  pass "assertion I is the one that fails"
+else
+  fail "assertion I did not fail" "$OUT_I"
+fi
+
+if echo "$OUT_I" | grep -q "clinical:ProgressNote is targeted"; then
+  pass "names clinical:ProgressNote in the finding"
+else
+  fail "did not name the offending class" "$OUT_I"
+fi
+
+if echo "$OUT_I" | grep -q "^PASS  T "; then
+  pass "assertion T still passes, so I is not a duplicate of T"
+else
+  fail "assertion T also failed; the two assertions are not independent" "$OUT_I"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Negative control for C (value-class closure).
+#
+#    genomics:HaplotypeShape accepts components typed genomics:Variant or
+#    genomics:CopyNumberVariant. Swap the second alternative for an unrelated
+#    class and the site stops accepting the subclass, which an entailing
+#    validator would still let through.
+# ---------------------------------------------------------------------------
+echo ""
+echo "5. Negative control C: narrow an sh:class site so it excludes a subclass"
+
+DIR="$(scratch c)"
+sed 's/\[ sh:class genomics:CopyNumberVariant \]/[ sh:class genomics:Haplotype ]/' \
+  "$SPEC_ROOT/$GEN" > "$DIR/$GEN.tmp"
+mv "$DIR/$GEN.tmp" "$DIR/$GEN"
+
+if ! cmp -s "$SPEC_ROOT/$GEN" "$DIR/$GEN"; then
+  pass "mutation applied (sh:or alternative replaced)"
+else
+  fail "mutation did not change the file" "expected '[ sh:class genomics:CopyNumberVariant ]' in $GEN"
+fi
+
+OUT_C="$("$PYTHON" "$CHECK" "$DIR" 2>&1)"
+STATUS_C=$?
+if [ $STATUS_C -ne 0 ]; then
+  pass "check fails against the reintroduced violation (exit $STATUS_C)"
+else
+  fail "check PASSED against a known violation" "$OUT_C"
+fi
+
+if echo "$OUT_C" | grep -q "^FAIL  C "; then
+  pass "assertion C is the one that fails"
+else
+  fail "assertion C did not fail" "$OUT_C"
+fi
+
+if echo "$OUT_C" | grep -q "genomics:CopyNumberVariant"; then
+  pass "names genomics:CopyNumberVariant in the finding"
+else
+  fail "did not name the excluded subclass" "$OUT_C"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Emptiness control.
+#
+#    A corpus with classes and shapes but no rdfs:subClassOf edges gives
+#    assertions T and I nothing to examine. The check must report FAIL, not
+#    PASS: an assertion that inspected no cases has established nothing, and
+#    reporting it as green is precisely the failure this suite exists to catch.
+# ---------------------------------------------------------------------------
+echo ""
+echo "6. Emptiness control: a corpus with no subclass relationships at all"
+
+DIR="$WORK/empty"
+mkdir -p "$DIR/ontologies/example/v1"
+cat > "$DIR/ontologies/example/v1/example.ttl" <<'TTL'
+@prefix ex:   <https://ns.cascadeprotocol.org/example/v1#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+ex:Alpha a owl:Class .
+ex:Beta  a owl:Class .
+TTL
+cat > "$DIR/ontologies/example/v1/example.shapes.ttl" <<'TTL'
+@prefix ex:  <https://ns.cascadeprotocol.org/example/v1#> .
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+ex:AlphaShape a sh:NodeShape ;
+    sh:targetClass ex:Alpha ;
+    sh:property [ sh:path ex:link ; sh:class ex:Beta ] .
+TTL
+
+OUT_E="$("$PYTHON" "$CHECK" "$DIR" 2>&1)"
+STATUS_E=$?
+if [ $STATUS_E -ne 0 ]; then
+  pass "check fails when an assertion examined nothing (exit $STATUS_E)"
+else
+  fail "check PASSED while examining zero cases" "$OUT_E"
+fi
+
+if echo "$OUT_E" | grep -q "^EMPTY  *T " && echo "$OUT_E" | grep -q "^EMPTY  *I "; then
+  pass "assertions T and I are reported EMPTY, not PASS"
+else
+  fail "empty assertions were not reported as EMPTY" "$OUT_E"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. The check must refuse a root with no ontologies rather than pass it.
+# ---------------------------------------------------------------------------
+echo ""
+echo "7. Missing-corpus control: an empty root must error, not pass"
+
+DIR="$WORK/nothing"
+mkdir -p "$DIR"
+OUT_N="$("$PYTHON" "$CHECK" "$DIR" 2>&1)"
+STATUS_N=$?
+if [ $STATUS_N -ne 0 ]; then
+  pass "check errors on a root containing no ontologies (exit $STATUS_N)"
+else
+  fail "check PASSED on a root containing no ontologies" "$OUT_N"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=========================================================="
+echo "  passed:  $PASSED"
+echo "  failed:  $FAILED"
+echo "  skipped: $SKIPPED"
+echo "  total:   $((PASSED + FAILED + SKIPPED))"
+echo "=========================================================="
+echo ""
+
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/serialization/index.md
+++ b/serialization/index.md
@@ -180,6 +180,8 @@ The shapes use three severity levels:
 
 **Validation workflow:** To validate serialized data, load the appropriate shapes file and the data file into a SHACL validator (e.g., Apache Jena, pySHACL, or TopBraid). The validator will report violations, warnings, and informational messages according to the severity levels above.
 
+**Entailment.** Cascade shapes are authored so that no RDFS entailment or ontology merge is needed to reach a correct verdict, and so that performing one does not change the verdict either. A validator that loads only the shapes file and the data file is fully conforming. The rule, its rationale, and what it requires of shape authors and of conformance suites are stated normatively in [`validation/index.md`](../validation/index.md); implementers whose validator has an inferencing setting should read it before choosing one.
+
 ---
 
 ## 2. Medications

--- a/validation/index.md
+++ b/validation/index.md
@@ -1,0 +1,176 @@
+# Cascade Protocol Validation Profile
+
+**Version:** 1.0
+**Date:** 2026-08-03
+**Status:** Normative
+**Organization:** Cascade Agentic Labs LLC
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+---
+
+## 1. Scope
+
+[SHACL](https://www.w3.org/TR/shacl/) is a validation language, not a validation *configuration*. Two implementations can both conform to the SHACL specification and still return opposite verdicts on the same data and the same shapes, because the specification leaves the choice of pre-validation inferencing to the deployment. That freedom is deliberate in SHACL. It is not acceptable in Cascade Protocol, where a Pod is expected to travel between a command-line tool, a mobile SDK, a conformance suite and a third-party consumer and be judged the same way by each.
+
+This document fixes that freedom. It states the **entailment regime** Cascade Protocol shapes assume, what a conforming validator must and must not do about it, and what a shape author must do so that the two never come apart.
+
+It applies to:
+
+- every `.shapes.ttl` file published in this repository;
+- every implementation that claims to validate Cascade Protocol data;
+- every conformance suite that certifies such an implementation.
+
+It does not change any vocabulary. It states a property the vocabularies already have and makes that property testable.
+
+---
+
+## 2. The problem this profile solves
+
+`sh:targetClass` selects its focus nodes by class membership. [SHACL §2.1.3.2](https://www.w3.org/TR/shacl/#targetClass) defines those nodes as the *SHACL instances* of the named class, and [§1.1](https://www.w3.org/TR/shacl/#dfn-shacl-instance) defines a node `n` as a SHACL instance of class `C` **in a graph `G`** when one of the SHACL types of `n` in `G` is `C`, where SHACL types follow `rdf:type/rdfs:subClassOf*` within `G`. For validation, `G` is the data graph. The subclass chain is therefore read from the data being validated, not from the ontology that declares it.
+
+[SHACL §1.5](https://www.w3.org/TR/shacl/#entailment) is explicit that this is a deployment choice rather than a fixed one: "full RDFS inferencing is not required", and "SHACL processors MAY, but are not required to, support entailment regimes".
+
+Cascade Protocol records carry `rdf:type` triples. They do not carry `rdfs:subClassOf` triples; schema axioms live in the ontology files and are not serialized into Pod data (see [`serialization/index.md`](../serialization/index.md) and [`pod-structure.md`](../pod-structure.md)). The consequence is exact and easy to miss:
+
+> A subclass axiom that lives only in an ontology file confers no shape coverage on the subclass. A shape targeting `Parent` does not fire on a node typed `Child`, even where `Child rdfs:subClassOf Parent` is declared.
+
+A validator that merges the ontology into the data graph first, or that applies RDFS entailment, sees the opposite. Both behaviours are defensible readings of SHACL. The result is that the same file is valid under one implementation and invalid under another, and neither implementation is doing anything wrong.
+
+This is not hypothetical. Measured on this repository's own shapes: a `genomics:CopyNumberVariant` missing `genomics:dataQualityTier` and missing every stable identifier was reported **conforming** by a validator that performs no entailment and **non-conforming, with two Violation-severity results**, by one that merges the subclass axioms. `genomics:CopyNumberVariant rdfs:subClassOf genomics:Variant` was declared, and `genomics:CopyNumberVariantShape` said in its own comment that `VariantShape`'s constraints "apply transitively". They did not. The rule below, and the check that enforces it, exist because a shape can assert an inheritance it does not have and nothing will contradict it.
+
+---
+
+## 3. Normative rules
+
+### 3.1 Rules for validators
+
+**V1. Class membership is read from the data graph.**
+A conforming validator MUST resolve `sh:targetClass`, `sh:class`, and every other class-membership test over the data graph as supplied, per SHACL §1.1 and §2.1.3.2. No shape published by this specification requires entailment to reach a correct verdict, and none ever will; a validator that performs no inferencing whatsoever is fully conforming.
+
+**V2. Entailment is permitted, and is an extension.**
+A validator MAY apply RDFS entailment, OWL reasoning, or a pre-validation merge of ontology files into the data graph. This is an implementation extension, not a requirement. A validator that does so SHOULD say so in its output or its documentation, so that two reports can be compared knowingly.
+
+**V3. Entailment MUST NOT change the verdict.**
+For data conforming to the Cascade Pod serialization rules (that is, data carrying `rdf:type` triples and no schema axioms), applying V2 MUST NOT change the conformance verdict. A file that conforms without entailment MUST conform with it, and a file that fails without entailment MUST fail with it.
+
+V3 is a constraint on **shapes**, not on validators. It is satisfiable only because §3.2 requires shapes to be entailment-independent. A measured verdict difference between an entailing and a non-entailing validator is therefore a **defect in the shapes** and SHOULD be reported as such against this repository. It is never grounds for changing a validator's inferencing configuration.
+
+**V4. Reports MAY differ where verdicts do not.**
+V3 constrains the verdict and the set of *failing* focus nodes. It does not constrain result multiplicity or result granularity. An entailing validator may apply a superclass shape to a node both directly and through the subclass shape's `sh:node` reference, and so may report the same underlying problem more than once; an implementation of `sh:node` may report one aggregate result where another reports each nested result. Consumers MUST NOT treat a difference in result count as a difference in verdict.
+
+**V5. A conformance suite is bound by V1.**
+A suite that certifies Cascade validators MUST be able to reproduce each fixture's expected outcome under V1, with no pre-validation graph merge and no inferencing. A suite MAY additionally run its fixtures with entailment enabled, but a fixture whose expected outcome is reachable *only* with entailment does not test what implementations do, and MUST NOT be used to certify them.
+
+**V6. Cascade shapes graphs MUST NOT declare `sh:entailment`.**
+SHACL §1.5 lets a shapes graph require an entailment regime with `sh:entailment`, and obliges a processor that does not support the named regime to **signal a failure** rather than validate. No shapes file published here declares it, and none may: doing so would convert every strictly conforming, non-inferencing validator from a correct implementation into a hard error. Implementers can rely on the absence of `sh:entailment` from these files as a guarantee, not an accident.
+
+### 3.2 Rules for shape authors
+
+**S1. Every class a shape means to constrain carries an explicit `sh:targetClass`.**
+Targeting is never inherited. If `Child rdfs:subClassOf Parent` and a shape targets `Parent`, that shape does not reach `Child`; either the same shape MUST additionally name `Child` in `sh:targetClass`, or another shape MUST target `Child`. SHACL's implicit class targets ([§2.1.3.3](https://www.w3.org/TR/shacl/#implicit-targetClass), where a shape is itself declared an `rdfs:Class`) satisfy S1 equally, since they are stated in the shapes graph rather than inferred. This repository does not currently use them.
+
+**S2. Constraint inheritance MUST be stated, not inferred.**
+Where a subclass is required to satisfy its superclass's constraints, the shapes MUST say so by one of two idioms, both already in use here:
+
+*One shape, several targets.* The same node shape names the parent and every child:
+
+```turtle
+health:HealthProfileShape a sh:NodeShape ;
+    sh:targetClass health:HealthProfile ;
+    sh:targetClass health:ActivityData ;
+    sh:targetClass health:SleepData ;
+    # ... one line per subclass
+    sh:property [ ... ] .
+```
+
+*One shape per class, joined by `sh:node`.* Each child shape names the parent shape:
+
+```turtle
+clinical:ProgressNoteShape a sh:NodeShape ;
+    sh:targetClass clinical:ProgressNote ;
+    sh:node clinical:ClinicalDocumentShape ;   # explicit; applies in every validator
+    sh:property [ ... ] .                       # progress-note-specific additions
+```
+
+Prefer the second where the subclass adds constraints of its own, and the first where a single constraint set covers the whole family. Both are entailment-independent: `sh:node` is a constraint component evaluated on the focus node, so it applies whether or not the validator entails.
+
+**S3. `sh:class` value constraints MUST enumerate the acceptable subclasses.**
+`sh:class` is resolved exactly as `sh:targetClass` is. `sh:class Parent` accepts only nodes explicitly typed `Parent`; a value typed `Child` is rejected by a non-entailing validator and accepted by an entailing one. Where subclasses are acceptable values, list them:
+
+```turtle
+sh:property [
+    sh:path genomics:hasComponent ;
+    sh:or (
+        [ sh:class genomics:Variant ]
+        [ sh:class genomics:CopyNumberVariant ]
+    ) ;
+] .
+```
+
+The same applies to `sh:qualifiedValueShape` when its value shape is a class test.
+
+**S4. Do not write shapes that depend on `sh:targetSubjectsOf` / `sh:targetObjectsOf` to compensate.**
+Those targets select by predicate, not by class, so they are already entailment-independent and remain available. They are not a substitute for S1: a predicate-based target constrains the nodes that use a predicate, not the nodes of a class.
+
+### 3.3 Rule for ontology authors
+
+**O1. `rdfs:subClassOf` stays, and means what it always meant.**
+Nothing above discourages declaring subclass relationships. They make `rdfs:domain` and `rdfs:range` declarations true rather than contradicted, they carry the model's meaning to reasoning consumers, and they are the basis on which S1 and S2 identify what needs an explicit target. What they are not is a validation mechanism. Adding a subclass axiom changes what the ontology *means*; it changes nothing about what any validator *checks*.
+
+---
+
+## 4. Why this way
+
+The alternative rule would be to mandate the merge: require every conforming validator to load the ontology files and entail before validating. It was considered and rejected.
+
+- **It moves correctness into configuration.** Under the merge rule, a validator is correct only if it loaded the right ontology files, at the right versions, in the right way. Every consumer acquires a way to be silently wrong that has nothing to do with the data or the shapes.
+- **It is unenforceable where validation actually happens.** Much Cascade validation runs inside a library embedded in someone else's application, on a device, with no ability to fetch or bundle a full ontology set. A rule that such an implementation cannot follow is a rule that will be ignored.
+- **It widens the conformance surface.** Certifying "does this implementation validate correctly" becomes "does this implementation validate correctly *and* resolve, version, and merge ontologies correctly." The second half is a larger and more fragile problem than the first.
+- **The chosen rule costs one line per class.** An explicit `sh:targetClass` is a single line in a file this project already maintains, written once by the party that already knows the model. That is a far better place to pay the cost than in every consumer.
+
+The chosen rule also has the property that it cannot be quietly violated: whether a shape depends on entailment is decidable from the shapes and ontologies alone, with no data and no validator. §5 decides it on every change.
+
+---
+
+## 5. How this is enforced
+
+`scripts/check-shape-targets.py` evaluates the three shape-author rules over every ontology and shapes file in this repository, and fails the build if any is broken. It parses the files with [rdflib](https://rdflib.dev/) and reasons over the graph structure; it runs no validator and needs no data.
+
+| Assertion | Rule | What it proves |
+|---|---|---|
+| **T** target closure | S1 | No class sits under a targeted superclass without a target of its own. |
+| **I** constraint-set equivalence | S2 | Where a class and its superclass are both targeted, the subclass reaches the superclass's constraints explicitly (shared shape, or `sh:node`). |
+| **C** value-class closure | S3 | The set of classes accepted at any one `sh:class` site is closed under `rdfs:subClassOf`. |
+
+Run it directly:
+
+```sh
+python3 -m pip install -r scripts/requirements.txt
+python3 scripts/check-shape-targets.py
+```
+
+The check reports how many cases each assertion examined and **fails if any assertion examined none**. An assertion with nothing to inspect has proven nothing, and reporting that as a pass is the failure mode this whole document exists to prevent.
+
+`scripts/test-check-shape-targets.sh` is the check's own regression suite. Every assertion in it is paired with a negative control: a scratch copy of the repository with one entailment dependency deliberately reintroduced, which the check MUST catch, naming the offending class. An assertion that has never been observed failing is not evidence.
+
+The CI job `shapes` runs the check and its regression suite on every pull request that touches `ontologies/`. This is the first automated test of this repository's own shapes; previously nothing here verified that a shape fires, that its constraints are reachable, or that the class it targets exists. Extending it in that direction is the intended next step.
+
+---
+
+## 6. Consequences for downstream implementations
+
+**Validators.** No change is required of an implementation that already validates without inferencing; it was conforming and remains so. An implementation that merges ontologies keeps that behaviour under V2 and, by V3, will agree with the others on every verdict. Both SHOULD cite this document where their inferencing behaviour is configured, so the choice is visible rather than incidental.
+
+**Conformance suites.** Per V5, a fixture's expected outcome must be reproducible with no pre-validation merge. A suite that currently merges subclass axioms should verify that removing the merge does not change any fixture's outcome; where it does, the fixture was testing the suite's configuration rather than the implementation's behaviour.
+
+**Shape consumers that bundle copies of these shapes.** Bundled copies inherit these guarantees only if they are complete. A partial sync that drops a `sh:targetClass` line silently reintroduces exactly the gap S1 forbids, so consumers that vendor shapes SHOULD assert that every `sh:targetClass` in their bundled copy resolves to a class in their bundled vocabulary.
+
+---
+
+## 7. References
+
+- [Shapes Constraint Language (SHACL)](https://www.w3.org/TR/shacl/). W3C Recommendation. §1.1 (SHACL instance), §1.5 (relationship to RDFS inferencing, `sh:entailment`), §2.1.3.2 (`sh:targetClass`), §4.1.1 (`sh:class`), §4.7.1 (`sh:node`).
+- [RDF Schema 1.1](https://www.w3.org/TR/rdf-schema/), for `rdfs:subClassOf`.
+- [`serialization/index.md`](../serialization/index.md), how Cascade data is serialized, and §1.7 on the role of the shapes files.
+- [`pod-structure.md`](../pod-structure.md), Pod layout; the reason data graphs carry no schema axioms.


### PR DESCRIPTION
## Vocabulary Change Summary

**Vocabulary:** none (cross-cutting). Shapes-only correction in `genomics/v1-draft`.
**Version bump:** **none.** `VOCAB_VERSIONS` is unchanged. New `validation/index.md` carries its own version (Validation Profile 1.0), as `serialization/index.md` does. `genomics` is a draft and is unrowed in `VOCAB_VERSIONS` per D-PATH; its changelog moves to `v1-draft.0.5`.
**Type of change:** normative clarification + first automated test of this repository's own shapes + one shape tightening and one relaxation in a draft vocabulary.

**Do not merge on my say-so. No tags are prepared and none should be pushed.**

---

## The problem

SHACL is a validation language, not a validation *configuration*. It resolves class membership over the **data** graph ([§2.1.3.2](https://www.w3.org/TR/shacl/#targetClass); a SHACL instance of `C` in graph `G` is a node one of whose SHACL types *in `G`* is `C`, [§1.1](https://www.w3.org/TR/shacl/#dfn-shacl-instance)), and it leaves pre-validation inferencing to the deployment ([§1.5](https://www.w3.org/TR/shacl/#entailment): "full RDFS inferencing is not required"; "SHACL processors MAY, but are not required to, support entailment regimes").

Cascade Pod records carry `rdf:type` triples and no schema axioms. So a subclass axiom declared in an ontology file confers **no** shape coverage on the subclass. A validator that merges ontologies into the data graph first sees the opposite. Both readings conform to SHACL. The consequence is that the same file can be valid under one implementation and invalid under another with neither doing anything wrong, and a conformance suite configured the entailing way certifies implementations against semantics they do not implement.

## What this PR does

1. **States the rule** in a new normative document, `validation/index.md`.
2. **Enforces it** with `scripts/check-shape-targets.py`, its regression suite, and a CI job.
3. **Fixes the two live violations the check found on its first run**, both in `genomics/v1-draft`.

Deliberately **not** in this PR: no tool's inferencing flags are changed. Matching two tools' configuration before the rule exists just relocates the ambiguity. The rule is here; the tools follow in their own repos, per `PENDING_DOWNSTREAM_SYNC.md`.

---

## The rule, as worded

**For validators (`validation/index.md` §3.1)**

- **V1.** Class membership is read from the data graph as supplied. No shape published here requires entailment to reach a correct verdict; a validator that performs no inferencing whatsoever is fully conforming.
- **V2.** Entailment or an ontology merge is **permitted**, as an extension, never required. A validator that does it SHOULD say so.
- **V3.** Doing it **MUST NOT change the verdict.** V3 is a constraint on *shapes*, not validators: a measured verdict difference between an entailing and a non-entailing validator is a **defect in the shapes**, reportable here, and never grounds for changing a validator's configuration.
- **V4.** Reports MAY differ where verdicts do not. V3 constrains the verdict and the failing focus nodes, not result multiplicity. (Measured below: it genuinely cannot constrain counts.)
- **V5.** A conformance suite MUST be able to reproduce every fixture's expected outcome under V1. A fixture whose expected outcome is reachable *only* with entailment does not test what implementations do and MUST NOT be used to certify them.
- **V6.** Cascade shapes graphs MUST NOT declare `sh:entailment`. SHACL obliges a processor that does not support a declared regime to *signal a failure* rather than validate, so declaring one would convert every strictly conforming validator into a hard error. None of the 10 shapes files declares it today; this makes that a guarantee rather than an accident.

**For shape authors (§3.2)**

- **S1.** Every class a shape means to constrain carries an explicit `sh:targetClass`. Targeting is never inherited. (SHACL implicit class targets satisfy S1 equally; unused here.)
- **S2.** Constraint inheritance is *stated*, by one shape naming parent and children in `sh:targetClass`, or by the child's shape naming the parent's shape with `sh:node`. Both idioms are already in use in this repo (`health:HealthProfileShape`, `clinical:ProgressNoteShape`).
- **S3.** `sh:class` value constraints enumerate the acceptable subclasses with `sh:or`. `sh:class Parent` rejects a value typed `Child`.
- **S4.** `sh:targetSubjectsOf` / `sh:targetObjectsOf` select by predicate, are already entailment-independent, and are not a substitute for S1.

**For ontology authors (§3.3)**

- **O1.** `rdfs:subClassOf` stays and means what it always meant. It makes `rdfs:domain` / `rdfs:range` true, carries meaning to reasoning consumers, and is what identifies which classes need an explicit target. It is simply not a validation mechanism.

**Why not the alternative** (§4). Mandating the merge was considered and rejected: it moves correctness into every consumer's configuration, is unenforceable in a library embedded in someone else's application with no ability to bundle a full ontology set, and widens certification from "does this implementation validate correctly" to "and does it resolve, version and merge ontologies correctly". The chosen rule costs one line per class, written once, by the party that already knows the model.

---

## Cross-engine evidence

Two engines, configured exactly as the two existing consumers configure them. Engine A: `rdf-validate-shacl` + `n3`, shapes in a separate store, no merge. Engine B: `pyshacl` with `ont_graph` = the `rdfs:subClassOf` axioms, `advanced=True`, `inference="none"`.

**Case 1: `genomics:CopyNumberVariant`, real shapes from this repo.** Fixture is a CNV satisfying every `CopyNumberVariantShape` constraint and none of the `VariantShape` constraints it was documented as inheriting (no `dataQualityTier`, no stable identifier).

| shapes | engine A (no entailment) | engine B (merges axioms) |
|---|---|---|
| `origin/main` | `conforms=true`, 0 results | `conforms=false`, 2 results (Violation: `dataQualityTier`; Violation: `sh:or` stable-ID) |
| this branch | `conforms=false`, 1 result | `conforms=false`, 5 results |

**Opposite verdicts before. Same verdict after.** The result counts still differ after the fix and cannot be made to agree, because the entailing engine applies `VariantShape` twice (once through `sh:node`, once through its expanded target set) while `rdf-validate-shacl` reports one aggregate `NodeConstraintComponent`. That is exactly why V4 is worded as "verdict and failing focus nodes", not "identical reports". I would have got this wrong without measuring it.

**Case 2: `clinical:ConsultationNote`**, the class this repo already fixed. Fixture is a consultation note with none of `ClinicalDocumentShape`'s six required fields; the mutation removes its explicit `sh:targetClass`.

| shapes | engine A | engine B |
|---|---|---|
| target removed | `conforms=true`, 0 results | `conforms=false`, 6 results |
| target present (as shipped) | `conforms=false`, 1 result | `conforms=false`, 13 results |

Both cases are the same failure, in two vocabularies, found five months apart.

---

## The check, and its negative controls

`scripts/check-shape-targets.py` parses all 21 ontology and shapes files with rdflib and reasons over graph structure. It runs no validator and needs no data, so whether a shape depends on entailment is decidable from this repository alone.

| | rule | result on this branch |
|---|---|---|
| **T** target closure | S1 | PASS, 14 cases examined |
| **I** constraint-set equivalence | S2 | PASS, 14 cases examined |
| **C** value-class closure | S3 | PASS, 29 cases examined |

Against `origin/main` it is **red**: `FAIL I` and `FAIL C`, both naming `genomics:CopyNumberVariant`. That is the check's first-run finding, not a synthetic control.

**It fails when the feature is absent.** `scripts/test-check-shape-targets.sh`: **21 passed / 0 failed / 0 skipped / 21 total.** Each assertion is paired with a scratch copy of the repository carrying one deliberately reintroduced dependency, which the check must catch *and name*:

```
$ python3 scripts/check-shape-targets.py <copy with ConsultationNote's target deleted>
  classes targeted:  107

FAIL  T  target closure: 1 finding(s) over 14 case(s) examined
        clinical:ConsultationNote has no sh:targetClass but inherits from shaped clinical:ClinicalDocument
PASS  I  constraint-set equivalence: 13 case(s) examined
PASS  C  value-class closure: 29 case(s) examined

RESULT: FAIL, 1 of 3 assertion(s) failed.
exit=1
```

The other controls: removing `ProgressNoteShape`'s `sh:node` is caught by **I** and named, **while T stays green**, so I is not a duplicate of T; narrowing an `sh:class` site past a subclass is caught by **C** and named.

**What it does if the feature is absent.** The check reports how many cases each assertion examined and **exits non-zero if any examined none**. Proven with an emptiness control: a corpus with classes and shapes but no `rdfs:subClassOf` edges reports `EMPTY T` / `EMPTY I` and `RESULT: FAIL`, not PASS. A missing-corpus control confirms an empty root errors (exit 2) rather than passing. A missing rdflib is a hard error, never a degrade to a text scan and never a skip.

CI job `shapes` runs the suite and the check on every PR touching `ontologies/`. Verified from a clean venv with only `scripts/requirements.txt` installed: 21/21 and exit 0.

---

## The two findings, fixed here (genomics v1-draft.0.5)

1. **`CopyNumberVariantShape` asserted an inheritance it did not have.** Its comment said `VariantShape`'s constraints "apply transitively" via `rdfs:subClassOf`. They did not. CNVs were never checked for `genomics:dataQualityTier` or for carrying a stable identifier. The tier is not bookkeeping: the `D-QUALITY-TIER` safety constraint on `VariantInterpretation` is evaluated against it, so a consumer-grade pathogenic CNV call could pass unflagged. Fixed with `sh:node genomics:VariantShape`. **This is a tightening.** CNV records that were silently unchecked are now checked, so pods containing CNVs may report new violations after this lands. That means the validator improved, not that the data got worse.
2. **`HaplotypeShape`'s `hasComponent` excluded `CopyNumberVariant`.** `sh:class genomics:Variant` accepted only nodes explicitly typed `Variant`. Now enumerated with `sh:or`, matching the idiom `VariantInterpretationShape.variantInterpreted` already used three lines away. **This is a relaxation** for strict validators.

In both cases the misleading comment is replaced with an accurate statement of why the axiom alone is not enough.

The six released vocabularies (`core`, `health`, `clinical`, `coverage`, `checkup`, `pots`) already satisfy all three assertions and are **unchanged**.

---

## Version reasoning

**No version bump, and no tags to push.**

- `VOCAB_VERSIONS` records the version of a *vocabulary*: its classes, properties and shapes. The Validation Profile is not a vocabulary; it is a profile statement about how validators interpret any of them. Bumping `health` (or any other) for a cross-cutting validation document would put a number on that vocabulary saying it changed when it did not, and would send six downstream repos into a re-sync for content that touches none of their models.
- No released vocabulary's classes, properties or shapes change. The only shape edits are in `genomics/v1-draft`, which the genomics changelog explicitly excludes from `VOCAB_VERSIONS` until v1.0 graduation.
- The document does change what implementations must do, so it carries **its own version** and its own `CHANGELOG.md` entry, exactly as `serialization/index.md` carries "Version 2.0" independently.

The counter-argument, that a normative statement changing implementation obligations is vocabulary-affecting, is real but does not survive the mechanism: `VOCAB_VERSIONS` is consumed by `check-downstream-versions.sh` to detect *model* drift across seven repos. A bump here would report drift that no downstream model change can resolve.

---

## Pre-merge Checklist

### In this PR (`spec`)
- [x] `owl:versionInfo` bumped in modified TTL file(s) — **N/A**, no ontology `.ttl` modified; only `genomics.shapes.ttl`, per the `v1-draft.0.3` shapes-only precedent
- [x] `dct:modified` updated to today — **N/A**, same reason
- [x] Changelog comment added — `ontologies/genomics/CHANGELOG.md` (`v1-draft.0.5`) and top-level `CHANGELOG.md`
- [x] Corresponding `.shapes.ttl` updated — this PR *is* the shapes change
- [x] JSON-LD context updated — **N/A**, no new terms
- [x] `VOCAB_VERSIONS` updated — **deliberately not**, see Version reasoning
- [x] Commit tag planned — **none.** No vocabulary version moved, so there is nothing to tag

### Downstream (complete after merge, in order)

Recorded as a ledger row in `PENDING_DOWNSTREAM_SYNC.md`. Summary:

- [ ] `cascade-cli` — re-sync `src/shapes/genomics.shapes.ttl`; until then `cascade validate` will not check CNVs for `dataQualityTier`. Then cite `validation/index.md` at the shapes-loading site, so the (correct, conformant) decision not to entail is recorded as a decision.
- [ ] `conformance` — per V5, verify that removing the `ont_graph` merge changes no fixture's outcome. Any that changes was testing the runner's configuration rather than an implementation's behaviour.
- [ ] `cascadeprotocol.org` — publish `validation/index.md`; add it to `sync-from-spec.sh`, which currently copies ontologies and contexts only.
- [ ] `sdk-typescript` / `sdk-python` / `cascade-agent` — no change. Neither SDK validates and no vocabulary term moved.
