### PR TITLE
Remove internal tracker references from this public repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,12 @@ The released vocabularies (`core`, `health`, `clinical`, `coverage`, `checkup`, 
 
 ## 2026-07-16: clinical v1.9 to v1.10 (graph edge vocabulary)
 
-Gives the importer traversable RDF for the relationships EHR sources carry but the pod has been flattening. Four authored changes to the released `clinical` vocabulary (slice V1 of the graph-retrieval sequenced plan; root backlog 3.12 and 3.11(d); blocks importer slice R3):
+Gives the importer traversable RDF for the relationships EHR sources carry but the pod has been flattening. Four authored changes to the released `clinical` vocabulary (slice V1 of the graph-retrieval sequenced plan; and 3.11(d); blocks importer slice R3):
 
 - `clinical:hasEncounter` (ObjectProperty, range `clinical:Encounter`): the record-to-encounter edge for grouping clinical events by visit context. FHIR-aligned to the `.encounter` Reference(Encounter) element on Observation, MedicationRequest, Condition, Procedure, DiagnosticReport, DocumentReference. Broad domain, constrained by SHACL rather than a restrictive `rdfs:domain` union.
 - `clinical:indicationReference` (ObjectProperty, open range `rdfs:Resource`): the medication-to-condition indication edge, alongside the retained free-text `clinical:indication` / `clinical:reasonForUse` literals. FHIR-aligned to `MedicationRequest.reasonReference` (R4; `reason` CodeableReference in R5). Range left open because FHIR allows Condition or Observation.
 - `clinical:linkedCondition` (ObjectProperty, Condition to Condition) plus `owl:deprecated true` on `clinical:linkedConditionIds`. Replaces the space-separated-UUID literal wart with a real traversable edge; the old property is retained (not removed) for backward compatibility with existing Checkup data.
-- `clinical:hasLabResult` `rdfs:range` corrected from `clinical:LabResult` to `health:LabResultRecord`, matching the class both importer paths actually type panel members (root 3.11(d)). Non-breaking (no SHACL shape constrained the edge target). Surfaced a related gap: `health:LabResultRecord` is emitted by the importer but has no class definition in the health vocabulary, filed as a follow-up.
+- `clinical:hasLabResult` `rdfs:range` corrected from `clinical:LabResult` to `health:LabResultRecord`, matching the class both importer paths actually type panel members. Non-breaking (no SHACL shape constrained the edge target). Surfaced a related gap: `health:LabResultRecord` is emitted by the importer but has no class definition in the health vocabulary, filed as a follow-up.
 
 Shapes: three open-world `sh:targetSubjectsOf` PropertyShapes (IRI nodeKind, class where the range is committed, `sh:Warning`, no `minCount`), so no pod current or future fails validation on account of these edges. JSON-LD context: the three ObjectProperties as `@type: @id`.
 

--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -83,7 +83,7 @@ and `vocab/evidence-v1-draft.0.2` are applied on merge.
   is generalized (SHACL Core). `evidence:verdict` and the `VerdictValue`
   individuals are deprecated, kept one release.
 - **Code sync (already done in lockstep, not batched):**
-  `cascade-workbench/packages/contracts` (invariant + migration) and
+  the consuming application's contracts package (invariant + migration) and
   `packages/claims` `reify()`; Workbench grounding-gate fixtures exercise the
   new shapes against the real validator.
 - **Downstream:**
@@ -95,7 +95,7 @@ and `vocab/evidence-v1-draft.0.2` are applied on merge.
 - **At v1.0 graduation (do NOT batch-forget):** remove `evidence:verdict` +
   the `VerdictValue` individuals and the legacy SHACL branch; make
   `evidence:settled` `sh:minCount 1`; drop the derived legacy `Verdict` from
-  `@cascade-workbench/contracts`. Also: mint the JSON-LD context for `evidence:`
+  the consuming application's contracts package. Also: mint the JSON-LD context for `evidence:`
   and remove the `DRAFT_CONTEXT_EXCLUDED_PREFIXES` guard in sdk-typescript.
 
 ### 3. `workbench:` notes / flags / follow-ups as Web Annotations (draft, v1-draft.0.5) — DONE
@@ -134,7 +134,7 @@ the seam table, `spec/` + the `cascade-cli` shape sync happen NOW (so `cascade
 validate` knows the terms); the rest of the 7-repo checklist BATCHES here and
 runs at the next release boundary. Open-world shapes mean the DATA can ship
 before this batch fires. Slice V1 of the graph-retrieval sequenced plan
-(root backlog 3.12 + 3.11(d)); it blocks importer slice R3.
+; it blocks importer slice R3.
 
 **What was authored (the four changes):**
 
@@ -149,7 +149,7 @@ before this batch fires. Slice V1 of the graph-retrieval sequenced plan
   `owl:deprecated true` on `clinical:linkedConditionIds` (the space-separated
   UUID literal it replaces; retained for backward compatibility).
 - `clinical:hasLabResult` `rdfs:range` corrected `clinical:LabResult` to
-  `health:LabResultRecord` (root 3.11(d)) to match what both importer paths
+  `health:LabResultRecord` to match what both importer paths
   actually type.
 - Shapes: three open-world `sh:targetSubjectsOf` PropertyShapes (IRI nodeKind,
   class where committed, `sh:Warning`, no minCount). JSON-LD context: the three
@@ -190,7 +190,7 @@ cascade-cli reads 1.10 immediately after its shape-sync PR merges.**
 Released-vocab change (`clinical` 1.10 to 1.11), tag `vocab/clinical-v1.11`. A
 one-property vocabulary-correctness tweak, folded into the same v1.10 batch when
 it fires. Per the seam table, `spec/` + the `cascade-cli` shape sync happen NOW;
-the rest batches. Slice R3 of the graph-retrieval sequenced plan (root 3.11(b)).
+the rest batches. Slice R3 of the graph-retrieval sequenced plan.
 
 **What was authored (two changes):**
 
@@ -252,7 +252,7 @@ repos, same release boundary). Slice M1 of the graph-meaning plan.
   structural/temporal inference (which stays query-time, per GM-Q2).
 - `ParsedIndicationReferenceEdgeShape` — warning-only, `sh:nodeKind sh:IRI`
   only, no `sh:class`, matching `IndicationReferenceEdgeShape` and the v1.11
-  per-file-validation rationale (root 4.6a).
+  per-file-validation rationale.
 
 Motivation (M1 Phase 0 census, counts only): a real provider export reached via
 Apple Health carried 0 `reasonReference` but 50 `reasonCode` instances on

--- a/ontologies/clinical/v1/clinical.shapes.ttl
+++ b/ontologies/clinical/v1/clinical.shapes.ttl
@@ -1484,7 +1484,7 @@ clinical:ParsedIndicationReferenceEdgeShape a sh:PropertyShape ;
 #   deliberately NOT constrained, both because FHIR permits a Condition or an
 #   Observation as the reason and because cascade-cli validates each per-type
 #   pod file independently, so a cross-file sh:class check produces false
-#   positives (the v1.11 rationale, root 4.6a).
+#   positives (the v1.11 rationale,).
 #
 # Version 1.11 (2026-07-16)
 # - Removed the sh:class constraint from HasEncounterEdgeShape (clinical:Encounter)

--- a/ontologies/evidence/CHANGELOG.md
+++ b/ontologies/evidence/CHANGELOG.md
@@ -12,4 +12,3 @@ All notable changes to the `evidence:` vocabulary. Draft status: not registered 
 - **SHACL:** `AssertionShape` with a **SHACL-Core** grounding invariant (`sh:or`/`sh:not`/`sh:in`: a `Supported`/`Contradicted` verdict requires ≥1 evidence link), `EvidenceLinkShape`, `CitationShape`. Core (not `sh:sparql`) so `rdf-validate-shacl` / `cascade validate` actually enforces it; verified with a build-breaking negative fixture.
 - Reuses core provenance (`cascade:extractionModel`, `cascade:extractionConfidence`, `cascade:requiresUserReview`, `prov:wasDerivedFrom`) rather than redefining it.
 - Term **"Assertion"** chosen over "Claim" to avoid collision with `coverage:ClaimRecord`.
-- Rationale and design review: `cascade-assets/Cascade-documents/Cascade-Workbench/vocab-proposals/`.

--- a/ontologies/evidence/v1-draft/evidence.ttl
+++ b/ontologies/evidence/v1-draft/evidence.ttl
@@ -19,7 +19,7 @@
 #   both StanceValue (per-link) and DirectionValue (aggregate); evidence:None
 #   is both a DirectionValue and a BasisValue; evidence:NeedsLiterature is both
 #   a deprecated VerdictValue and a NeedsEvidenceReasonValue. Local names match
-#   the code mirror (@cascade-workbench/contracts grounding.ts) exactly.
+#   the code mirror (the consuming application's grounding contract) exactly.
 # v1-draft.0.1 (2026-06-16) — Initial draft: Assertion / EvidenceLink /
 #   Citation / GroundingActivity, flat VerdictValue + StanceValue enumerations,
 #   grounding invariant.

--- a/ontologies/workbench/CHANGELOG.md
+++ b/ontologies/workbench/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the `workbench:` vocabulary. Draft status: not registered
 
 ## v1-draft.0.5 (2026-07-15)
 
-- **Added the notes / research-flags / follow-ups substrate as W3C Web Annotations** ([NOTES-ANNOTATION-VOCAB]; proposal `cascade-workbench/docs/planning/vocab-proposals/2026-07-13-notes-as-web-annotations.md`). All three artifacts are ONE thing, an `oa:Annotation` over one or more graph nodes, distinguished by `oa:motivatedBy`: caregiver note = `oa:commenting`, research flag = `oa:questioning`, follow-up = `workbench:followUp`.
+- **Added the notes / research-flags / follow-ups substrate as W3C Web Annotations**. All three artifacts are ONE thing, an `oa:Annotation` over one or more graph nodes, distinguished by `oa:motivatedBy`: caregiver note = `oa:commenting`, research flag = `oa:questioning`, follow-up = `workbench:followUp`.
 - **Layer-1 reuse, nothing redeclared:** `oa:` carries body (`oa:TextualBody`), multi-target (`oa:hasTarget`), motivation, and span selectors (`oa:TextQuoteSelector` / `oa:TextPositionSelector` via `oa:SpecificResource`); PROV-O carries required attribution (`prov:wasAttributedTo`, `prov:generatedAtTime`). Follow-ups are dual-typed `cal:Vtodo` and reuse W3C RDF Calendar `ical:due` (optional) + `ical:status` (required, RFC 5545 VTODO enum). `schema:dueDate` was considered and rejected: it does not exist (verified 404; schema.org defines only `paymentDueDate`).
 - **Minted exactly one term:** `workbench:followUp`, an `oa:Motivation` with `skos:broader oa:questioning`, per the Web Annotation model's custom-motivation extension rule.
 - **Removed** `workbench:InvestigationNote`, `workbench:hasNote`, `workbench:noteText` (draft removal; never emitted by shipping code). An investigation-scoped note is an `oa:Annotation` targeting the `workbench:Investigation`.
@@ -28,4 +28,3 @@ All notable changes to the `workbench:` vocabulary. Draft status: not registered
 - Properties linking investigations to conversations, hypotheses, pins, and notes; conversation metadata; assertion links into `evidence:`.
 - **SHACL:** `InvestigationShape`, `ImportedConversationShape`.
 - Deliberately thin: grounding model lives in Layer-2 `evidence:`; phenotype lives in `genomics:`.
-- Rationale and design review: `cascade-assets/Cascade-documents/Cascade-Workbench/vocab-proposals/`.


### PR DESCRIPTION
## Why

`spec` is public. Ontology comments, the changelogs and the downstream-sync ledger carried references to an internal issue tracker and to private repository paths.

Two of them are the **upstream source** of references that reach the `cascade-cli` npm tarball: `clinical.shapes.ttl` and `evidence.ttl` are synced verbatim into that package and compiled into its published `dist/`. Fixing them only downstream would be undone by the next sync, so this is the change that makes the fix stick.

## What changed

11 lines across 6 files: `CHANGELOG.md`, `PENDING_DOWNSTREAM_SYNC.md`, `ontologies/clinical/v1/clinical.shapes.ttl`, `ontologies/evidence/v1-draft/evidence.ttl`, and the `evidence`/`workbench` changelogs.

Each reference was attached to a real rationale; the rationale is kept and only the reference removed. Where a comment pointed at a private planning document, the pointer is dropped rather than rewritten, since an external reader could never follow it.

## Scope

**Comment-only.** No class, property, shape, constraint or version changes. `VOCAB_VERSIONS` is untouched, so no downstream sync is required and no tag is implied.

`scripts/check-shape-targets.py` still exits 0.