### PR TITLE
docs: document the full cross-repo vocabulary sequence, add AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+Canonical source for every Cascade Protocol vocabulary: OWL ontologies, SHACL shapes, JSON-LD contexts, and serialization rules.
+
+## Start here
+
+- `CLAUDE.md` -- repository structure, the three-layer ontology architecture, how shapes relate to ontologies, version bumping.
+- `CONTRIBUTING.md` -- the contribution process, and the full seven-step sequence for propagating a vocabulary change across the protocol.
+- `validation/index.md` -- the Validation Profile. Read it before authoring or editing any shape.
+
+`CLAUDE.md` and this file describe the same repository. `CLAUDE.md` is loaded automatically by Claude Code; this file exists so any coding agent finds the same instructions.
+
+## Protocol context
+
+<https://cascadeprotocol.org/llms.txt> is the protocol index: install, quick start, data types, MCP server, security model, vocabulary versions, deployment sequence. About 95 lines, meant to be read in full.
+
+Do **not** load `llms-full.txt` from that site. It is roughly 1.3 MB, larger than most working contexts, and as of 2026-08-20 its ontology section is known to be incomplete. The TTL files in this repository are the source of truth.
+
+## Ground rules
+
+- **This repository is where vocabulary is authored, and the only one.** Every other repository carries a derived copy. A change here that is not propagated leaves them stale.
+- **A shape never reaches a class through `rdfs:subClassOf`.** SHACL resolves class membership over the data graph; pod records carry `rdf:type` and no schema axioms. Every class you mean to constrain gets its own `sh:targetClass`. This has been authored wrong twice, both times with a comment claiming an inheritance the shape did not have. Run the check rather than trusting the comment.
+- **Never weaken a check to make it pass.** The negative controls in `scripts/testdata/` are frozen specimens; their bugs are what make the controls meaningful.
+- **Defer to ratified standards.** Map to FHIR, SNOMED CT, LOINC or RxNorm where one covers the concept, and cite the canonical source. Invent vocabulary only where none exists.
+- Any change to a `.ttl` file must bump `owl:versionInfo`, update `dct:modified`, add a changelog comment, and update `VOCAB_VERSIONS`. The pre-commit hook enforces the first of those.
+
+## What must be green
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r scripts/requirements.txt
+
+sh scripts/test-check-shape-targets.sh     # the rule's own regression suite
+python3 scripts/check-shape-targets.py     # the rule, against this repository
+
+# only if you touched the drift check itself (POSIX sh, CI runs it under dash)
+dash scripts/test-check-downstream-versions.sh
+```
+
+Both of the first two must exit 0. CI runs them on every PR touching `ontologies/`.
+
+**Activate the venv rather than calling its interpreter by path**: the scripts shell out to `python3`. Without `rdflib` both checks exit 2 and say so rather than passing vacuously, because the check parses Turtle and cannot degrade to a text scan without becoming unsound.
+
+## Conventions
+
+- Commits: `<type>(scope): <vocab>: <description>`, for example `docs(schema): clinical: add ImmunizationRecord class`.
+- Tags: `vocab/{name}-v{X.Y}`, for example `vocab/clinical-v1.8`.
+- Branch from `main`; open a PR rather than pushing to it.
+- Report anything you could not finish, especially downstream steps you lacked access to complete, in the PR body rather than only in a commit message.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,99 +1,201 @@
 # Contributing to Cascade Protocol Specification
 
-Thank you for your interest in contributing to the Cascade Protocol specification. This document describes how to propose changes to vocabularies, add SHACL shapes, and follow our development process.
+Thank you for your interest in contributing to the Cascade Protocol specification. This repository is the canonical source for every Cascade vocabulary: the OWL ontologies, the SHACL shapes, the JSON-LD contexts, and the serialization rules.
 
-## Types of Contributions
+**`spec/` is the only place vocabulary is authored.** Every other repository in the protocol carries a copy, a model, a fixture or a prompt derived from what lands here. That is what makes the propagation sequence below load-bearing rather than bureaucratic: a change merged here and not carried downstream leaves five repositories describing a vocabulary that no longer exists, and nothing surfaces it until someone runs the drift check.
 
-### Vocabulary Changes (RFC Process)
+## Before you start
 
-Changes to ontology files (adding classes, properties, or modifying existing terms) follow a lightweight RFC process:
+Open issues across the protocol, and the subset suitable for a first contribution:
+
+- All open issues: <https://github.com/search?q=org%3Athe-cascade-protocol+is%3Aissue+is%3Aopen>
+- Good first issues: <https://github.com/search?q=org%3Athe-cascade-protocol+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22>
+
+### Types of contribution
+
+**Vocabulary changes (RFC process).** Adding classes or properties, or modifying existing terms, follows a lightweight RFC:
 
 1. **Open an issue** describing the proposed change, including:
-   - Which vocabulary is affected (core, health, clinical, coverage, etc.)
+   - Which vocabulary is affected (core, health, clinical, coverage, checkup, pots)
    - New classes or properties being added
    - Rationale and use case
-   - Mapping to established standards (FHIR, SNOMED CT, LOINC) if applicable
+   - Mapping to established standards (FHIR, SNOMED CT, LOINC, RxNorm) if applicable
+2. **Discussion period**: allow at least 7 days for feedback.
+3. **Submit a PR** implementing the change once consensus is reached. It must update every artifact in the checklist below.
+4. **Review**: at least one maintainer must approve vocabulary changes.
 
-2. **Discussion period**: Allow at least 7 days for community feedback.
+**Adding SHACL shapes.** When adding validation shapes for new or existing classes:
 
-3. **Submit a PR** implementing the change once consensus is reached. The PR must update all affected artifacts (see checklist below).
+1. Place shapes in `ontologies/<vocab>/v1/<vocab>.shapes.ttl`.
+2. Each shape must define `sh:targetClass` pointing at the ontology class, required-field constraints (`sh:minCount 1`), datatype constraints (`sh:datatype`), and enumeration constraints (`sh:in`) where applicable.
+3. Read `validation/index.md` first. The rule in one line: **a shape never reaches a class through `rdfs:subClassOf`.** SHACL resolves class membership over the data graph, and pod records carry `rdf:type` triples without schema axioms, so a subclass axiom confers nothing at validation time. Every class you mean to constrain gets its own `sh:targetClass`. This has been authored wrong twice, in two different vocabularies, both times with a comment claiming an inheritance the shape did not have.
+4. Add corresponding fixtures in [conformance](https://github.com/the-cascade-protocol/conformance).
 
-4. **Review**: At least one maintainer must approve vocabulary changes.
+**Documentation fixes.** Typos, clarifications and improved examples are always welcome. Open a PR directly, no RFC needed.
 
-### Adding SHACL Shapes
+## Development setup
 
-When adding validation shapes for new or existing classes:
+```bash
+git clone https://github.com/the-cascade-protocol/spec.git
+cd spec
 
-1. Place shapes in the appropriate `ontologies/<vocab>/v1/<vocab>.shapes.ttl` file
-2. Each shape must define:
-   - `sh:targetClass` pointing to the ontology class
-   - Required field constraints (`sh:minCount 1`)
-   - Datatype constraints (`sh:datatype`)
-   - Enumeration constraints (`sh:in`) where applicable
-3. Add corresponding conformance test fixtures in the [conformance](https://github.com/the-cascade-protocol/conformance) repository
+# Install the pre-commit hook. It blocks commits that modify a TTL file
+# without bumping owl:versionInfo.
+sh scripts/install-hooks.sh
 
-### Documentation Fixes
+# Python tooling for the shape checks. Use a virtual environment and ACTIVATE it:
+# the check scripts shell out to `python3`, so pointing at the venv interpreter
+# by path is not enough. A current macOS or Debian-family Python also refuses a
+# bare `pip install` outright (PEP 668, "externally-managed-environment").
+python3 -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install -r scripts/requirements.txt
+```
 
-Typos, clarifications, and improved examples are always welcome. Open a PR directly -- no RFC needed.
+Without `rdflib` installed both checks exit 2 and say so, rather than passing vacuously. That is deliberate: the check parses Turtle and cannot degrade to a text scan without becoming unsound.
 
-## Vocabulary Change Checklist
+Optionally, to validate against the CLI:
 
-When modifying any Cascade Protocol vocabulary, update ALL of the following artifacts:
+```bash
+npm install -g @the-cascade-protocol/cli
+cascade validate ontologies/clinical/v1/clinical.shapes.ttl
+```
 
-- [ ] **TTL ontology file** (source of truth) -- bump `owl:versionInfo`, update `dct:modified`, add changelog comment
-- [ ] **SHACL shapes file** -- add/update shapes for new classes or properties
-- [ ] **HTML documentation page** (e.g., `docs/clinical/v1/index.html`) -- update version refs, add class/property sections, add changelog entry
-- [ ] **`cascade-protocol-schemas.md`** -- update section heading version, class count, version history
-- [ ] **`docs/index.html`** -- update vocabulary card version badge
-- [ ] **Conformance fixtures** -- add test fixtures for new classes/properties in the [conformance repo](https://github.com/the-cascade-protocol/conformance)
+## What must be green before review
 
-## Commit Message Conventions
+Two CI jobs gate this repository. Run their commands locally before opening a PR.
 
-We use structured commit messages to maintain a clear changelog:
+```bash
+source .venv/bin/activate                  # both checks shell out to `python3`
+
+# shapes: the Validation Profile. Both must exit 0.
+sh scripts/test-check-shape-targets.sh     # the rule's own regression suite
+python3 scripts/check-shape-targets.py     # the rule, against this repository
+
+# drift-checker: only if you touched the downstream drift check itself.
+# POSIX sh, not bash. CI runs it under dash to catch bashisms.
+dash scripts/test-check-downstream-versions.sh
+```
+
+`scripts/check-shape-targets.py` runs on every PR touching `ontologies/`, together with its own negative controls, so a check that has stopped being able to fail is caught here rather than in a consumer. Do not "fix" the frozen specimens in `scripts/testdata/`; their bugs are what make the controls meaningful.
+
+## Commit messages
 
 ```
-docs(schema): <vocab>: <description>
+<type>(scope): <vocab>: <description>
+```
 
 Examples:
-  docs(schema): clinical: add ImmunizationRecord class
-  docs(schema): core: bump version to 1.4, add PharmacyInfo
-  docs(schema): coverage: fix InsurancePlan sh:pattern constraint
-  fix(shapes): clinical: correct MedicationShape required fields
+
+```
+docs(schema): clinical: add ImmunizationRecord class
+docs(schema): core: bump version to 1.4, add PharmacyInfo
+docs(schema): coverage: fix InsurancePlan sh:pattern constraint
+fix(shapes): clinical: correct MedicationShape required fields
 ```
 
-Format: `<type>(scope): <vocab>: <description>`
-
 Types:
+
 - `docs(schema)` -- vocabulary or documentation changes
 - `fix(shapes)` -- SHACL shape corrections
 - `feat(vocab)` -- new vocabulary terms
 - `chore` -- maintenance, tooling
 
-## Design Principles
+Tag format for a ratified vocabulary version: `vocab/{name}-v{X.Y}`, for example `vocab/clinical-v1.8`.
 
-When proposing new vocabulary terms, follow these principles:
+## Opening a pull request
 
-1. **Three-layer mapping**: Every data type should map through established standards (FHIR, SNOMED CT, LOINC) at Layer 1, domain vocabulary at Layer 2, and patient-facing vocabulary at Layer 3.
+1. Branch from `main`.
+2. Make the change, and complete the in-repo checklist below in the same PR.
+3. Run the two commands under "What must be green" and confirm both exit 0.
+4. Push and open a PR. `.github/PULL_REQUEST_TEMPLATE.md` fills in with the checklist; keep the items and tick them.
+5. Say in the PR body which downstream repositories you are able to update and which you are not. A contributor who cannot open PRs against all seven should still say so, so a maintainer can carry the rest rather than discovering the gap later.
+6. One maintainer approval is required for vocabulary changes. Documentation-only changes need one review.
 
-2. **Provenance-first**: All data must carry provenance metadata (`cascade:dataProvenance`). New classes must support the standard provenance values.
+## Vocabulary changes: the full cross-repo sequence
 
-3. **Local-first**: Vocabulary design must not require network access for validation or processing.
+This is the authoritative process. It is seven steps and it does not end when the `spec` PR merges.
 
-4. **Minimal but complete**: Add only what is needed. Each property should have a clear use case in at least one consuming application.
+### Step 1 -- `spec` (this repository)
 
-## Development Setup
+Before committing any change to an ontology (`.ttl`) file:
 
-To work with the ontology files locally:
+- [ ] Bump `owl:versionInfo` (the pre-commit hook blocks the commit otherwise)
+- [ ] Update `dct:modified` to today's date
+- [ ] Add a changelog comment block at the top of the TTL file
+- [ ] Update the corresponding `.shapes.ttl` if classes or properties were added
+- [ ] Update the JSON-LD context (`contexts/v1/{name}.jsonld`) if new terms need `@type` / `@id` mappings
+- [ ] Update `VOCAB_VERSIONS` and stage it explicitly: `git add VOCAB_VERSIONS`
+- [ ] `python3 scripts/check-shape-targets.py` exits 0
+- [ ] After committing, tag it: `git tag vocab/{name}-v{X.Y}`
+
+### Steps 2 through 7 -- downstream, in this order
+
+Order matters. Conformance fixtures gate the SDK releases, so a fixture that does not exist yet means an SDK cannot prove it implemented the class correctly.
+
+| # | Target | What to update |
+|---|--------|----------------|
+| 2 | Documentation site (`cascadeprotocol.org`) | Sync the TTL copies; update the per-vocabulary HTML page (`docs/<vocab>/v1/index.html`), `cascade-protocol-schemas.md` and the version badge on `docs/index.html`. **These artifacts live on the site, not in this repository.** |
+| 3 | [`conformance`](https://github.com/the-cascade-protocol/conformance) | Add a valid and an invalid fixture per new class, update the `dataType` enum in `schema/fixture-schema.json`, update `VOCAB_VERSIONS`, tag `conformance-v{YYYY-MM-DD}` |
+| 4 | [`cascade-cli`](https://github.com/the-cascade-protocol/cascade-cli) | Run `scripts/sync-shapes-from-spec.sh` (never hand-edit `src/shapes/`), update `VOCAB_VERSIONS`, CHANGELOG, package version |
+| 5 | [`sdk-typescript`](https://github.com/the-cascade-protocol/sdk-typescript) | Add `src/models/{class}.ts`, register predicates in `src/vocabularies/namespaces.ts` and `TYPE_MAPPING`, wire serializer, deserializer and JSON-LD context, export from `src/index.ts`, update `VOCAB_VERSIONS` |
+| 6 | [`sdk-python`](https://github.com/the-cascade-protocol/sdk-python) | Add `src/cascade_protocol/models/{class}.py`, register predicates in `vocabularies/namespaces.py`, register in serializer **and** deserializer, export from `__init__.py`, update `VOCAB_VERSIONS` |
+| 7 | [`cascade-agent`](https://github.com/the-cascade-protocol/cascade-agent) | Update the query patterns and field tables in `src/system-prompt.ts`, update `VOCAB_VERSIONS` |
+
+**Step 2 is maintainer-run.** The documentation site is not a public repository, so an outside contributor cannot open a PR against it. Do the six steps you can and note the site step in your PR; a maintainer completes it. Nothing else in the sequence depends on it.
+
+**Two failure modes worth naming, because both are silent:**
+
+- In `sdk-python`, registering a class in the serializer but not the deserializer makes `parse()` return an empty list rather than an error. A pod full of records reads as an empty pod. Test a round trip, never just a serialize.
+- In `conformance`, a fixture that no shape targets is reported `UNSHAPED`: zero constraints ran, so its PASS asserts nothing. A new fixture that passes vacuously is worse than no fixture.
+
+### Not every change fires all seven steps at once
+
+Propagating one change through six repositories is expensive, so authored changes
+accumulate and the full sync runs in a batch at a release boundary.
+`PENDING_DOWNSTREAM_SYNC.md` is the ledger of what is authored and not yet propagated.
+Add your change to it in the same PR when you cannot carry the sequence yourself.
+
+Batching is safe because Cascade shapes are open-world (not `sh:closed`): a tool can
+emit a new predicate and the Pod still passes `cascade validate` before that predicate
+reaches the embedded shapes. The data can ship as soon as `spec` defines the term.
+
+Two consequences worth knowing:
+
+- **Draft vocabularies do not fire the sequence at all.** A `v1-draft` namespace is not
+  listed in `VOCAB_VERSIONS` and gates no downstream release. Terms accrue in draft; the
+  seven steps run when a draft is promoted to a released `vN`.
+- **When a released vocabulary gains a property**, `spec` and `cascade-cli`'s embedded
+  shapes are the two to sync promptly, so `cascade validate` documents the new term.
+  The rest can batch.
+
+### The drift check
+
+At any point, from a `spec` checkout with the downstream repositories cloned as siblings:
 
 ```bash
-# Clone the repo
-git clone https://github.com/the-cascade-protocol/spec.git
-cd spec
-
-# Validate shapes with the CLI
-npm install -g @cascade-protocol/cli
-cascade validate ontologies/clinical/v1/clinical.shapes.ttl
+sh scripts/check-downstream-versions.sh
 ```
+
+It refreshes each repository's remote-tracking refs before reading them, so a sync that merged a moment ago is seen immediately rather than reported as drift. Besides drift itself, two conditions fail the run, both because they mean a repository was not actually checked: a downstream repository **not present** on disk, and a repository whose **fetch failed**, whose verdict prints as `UNVERIFIED`.
+
+`VOCAB_NO_FETCH=1` skips fetching for a deliberate offline run and labels every verdict as computed from unrefreshed refs. Do not use it to make a red gate green.
+
+## Design principles
+
+When proposing new vocabulary terms:
+
+1. **Defer to ratified standards.** Map through an established standard wherever one exists (FHIR, SNOMED CT, LOINC, RxNorm) and cite the canonical source in the issue. Author novel vocabulary only where no standard covers the concept.
+2. **Three-layer mapping.** Every data type maps through established standards at Layer 1, domain vocabulary at Layer 2 (`health:` for wellness and device data, `clinical:` for EHR data), and patient-facing vocabulary at Layer 3 (`checkup:`, `pots:`).
+3. **Provenance-first.** All data carries provenance metadata (`cascade:dataProvenance`). New classes must support the standard provenance values.
+4. **Local-first.** Vocabulary design must not require network access for validation or processing.
+5. **Minimal but complete.** Add only what is needed. Each property should have a clear use case in at least one consuming application.
+
+## Protocol context
+
+<https://cascadeprotocol.org/llms.txt> is the index of protocol context: install, quick start, supported data types, the MCP server, the security model, current vocabulary versions and this deployment sequence. It is about 95 lines and is meant to be read in full, by a person or an agent.
+
+There is also a `llms-full.txt` on that site. **Do not load it.** It is roughly 1.3 MB, larger than most working contexts, and as of 2026-08-20 its ontology section is known to be incomplete. Read the TTL files in this repository instead; they are the source of truth by definition.
 
 ## Questions?
 

--- a/PENDING_DOWNSTREAM_SYNC.md
+++ b/PENDING_DOWNSTREAM_SYNC.md
@@ -2,7 +2,7 @@
 
 **Purpose.** A vocabulary change is *authored* in `spec/` continuously, but its
 propagation to the six downstream repos (the steps 2–7 of the Vocabulary Change
-Checklist in the workspace `CLAUDE.md`) is **expensive to do one change at a
+Checklist in `CONTRIBUTING.md`) is **expensive to do one change at a
 time**. This ledger lets us accumulate authored-but-not-yet-propagated changes
 and run the full 7-repo sync **in one batch** at a release boundary (e.g. weekly,
 or when a draft vocab is promoted out of `v1-draft`).
@@ -31,7 +31,7 @@ on the CLI shape sync; do it promptly only so `validate` documents the new term.
 ## How to run the batch
 
 1. `cd spec && sh scripts/check-downstream-versions.sh` — see drift across repos.
-2. For each ledger row below, run the per-repo steps (CLAUDE.md checklist 2–7).
+2. For each ledger row below, run the per-repo steps (`CONTRIBUTING.md` cross-repo sequence, steps 2–7).
 3. Tag `vocab/{name}-v{X.Y}`, update each repo's `VOCAB_VERSIONS`, clear the row.
 
 ---
@@ -163,7 +163,7 @@ before this batch fires. Slice V1 of the graph-retrieval sequenced plan
       the-cascade-protocol/cascade-cli#21 (npm test 1034 green; fresh Synthea
       import validates 20/20 clean against the new shapes).
 
-**Batched (do NOT execute now; run at the next batch, per CLAUDE.md checklist 2-7):**
+**Batched (do NOT execute now; run at the next batch, per the `CONTRIBUTING.md` cross-repo sequence, steps 2-7):**
 
 - [ ] `cascadeprotocol.org` — `sync-from-spec.sh`, HTML docs (`docs/clinical/v1/`
       version refs, new property/shape sections, changelog entry) +


### PR DESCRIPTION
Part of the contributor onboarding kit: every public protocol repository gains a `CONTRIBUTING.md` and an `AGENTS.md`, consistent in structure, so the curated public issue set has conventions to point at.

`AGENTS.md` is a peer of `CLAUDE.md` rather than a replacement, so a contributor's choice of coding agent is not assumed. Every `AGENTS.md` in the org shares the same five sections in the same order: Start here, Protocol context, Ground rules, What must be green, Conventions. Every `CONTRIBUTING.md` shares the same backbone: Before you start, Development setup, What must be green before review, Commit messages, Opening a pull request, Vocabulary changes, Protocol context, Questions.

No file points a reader at `llms-full.txt` as a thing to load. All point at the ~95-line `llms.txt` index.

Docs only. No code, config or workflow changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)