### PR TITLE
drafts: adopt vs:term_status per term across all five draft vocabularies

### DIFF
--- a/.github/workflows/term-status.yml
+++ b/.github/workflows/term-status.yml
@@ -1,0 +1,44 @@
+name: term-status
+
+# Enforces per-term maturity on the draft vocabularies: every term declares
+# vs:term_status (W3C SemWeb Vocabulary Status, originating in FOAF), the value
+# is one of the four that ontology defines, and a term marked owl:deprecated is
+# marked archaic rather than something that contradicts it.
+#
+# Without this job the annotation is only a convention, and the convention has
+# already failed once: the pass that introduced it silently skipped 96 of 411
+# terms -- every term preceded by a section comment -- and reported success.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'ontologies/**'
+      - 'scripts/check-term-status.py'
+      - 'scripts/test-check-term-status.sh'
+      - 'scripts/requirements.txt'
+      - '.github/workflows/term-status.yml'
+  workflow_dispatch:
+
+jobs:
+  term-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: python3 -m pip install -r scripts/requirements.txt
+
+      # The regression suite runs the check against the repository AND against
+      # scratch copies with known defects reintroduced, so a check that has
+      # stopped being able to fail is caught here rather than in a consumer.
+      - name: Regression suite (check + negative controls)
+        run: sh scripts/test-check-term-status.sh
+
+      - name: Per-term status check
+        run: python3 scripts/check-term-status.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Format: each entry is one milestone, dated, with a short prose summary and point
 
 ---
 
+## 2026-08-20: Draft vocabularies carry per-term maturity (advisory, diabetes, evidence, genomics, workbench)
+
+Cascade stated maturity once per vocabulary, in prose a machine could not read: an ontology-level `owl:versionInfo "1.0-draft"` and an `rdfs:comment` saying the vocabulary is subject to change. That tells a consumer nothing about which individual terms are settled, so the only safe reading of a draft vocabulary was to treat all of it as provisional, including the parts that had not moved in three revisions.
+
+The ratified answer already exists and is not ours. [W3C SemWeb Vocabulary Status](http://www.w3.org/2003/06/sw-vocab-status/ns#), which originated in FOAF, defines `vs:term_status` with four values: `unstable`, `testing`, `stable`, `archaic`. Its own description states the design reason for the granularity, that indicating status at the term level rather than the vocabulary level makes fine-grained improvement easier. That is exactly the guarantee a `/v1#` namespace makes: the vocabulary evolves in place, and a term is promoted without minting a new namespace. This repository already used the matching standard at the other end of the lifecycle, `owl:deprecated`, 21 times.
+
+All 411 terms across the five draft vocabularies now carry `vs:term_status`. Terms are `unstable`, which is what a draft term is; the five terms already marked `owl:deprecated` are `archaic`. No term definition, domain, range, label or comment changed, and no triple was removed: the annotation was verified by diffing the parsed N-Triples of every file before and after, which must show the added status triples and nothing else.
+
+**The status is per term precisely so it can stop being uniform.** A blanket `unstable` across a draft vocabulary carries no more information than the prose it replaces. What it buys is the mechanism: promoting `evidence:Assertion` to `testing` is now a one-triple change a consumer can query, rather than a graduation event for the whole vocabulary. Vocabularies should promote terms as they settle, and the value of this change is only realised when they do.
+
+`owl:versionInfo` remains the vocabulary-level draft marker and is unchanged in meaning. The two answer different questions, and where both speak they must agree: a term marked `owl:deprecated` must be `archaic`, which `scripts/check-term-status.py` enforces, because two machine-readable maturity signals that contradict each other are worse than one.
+
+The check is gated in CI with negative controls, for a specific reason. The pass that added these annotations silently skipped 96 of 411 terms, every term that happened to be preceded by a section comment, and reported success. It was caught by auditing the parsed graph, never by the inserter's own count. A tool's report of what it did is not evidence that it did it.
+
+Also corrected here: `rdfs:seeAlso` on `advisory`, `diabetes` and `genomics` pointed at documentation paths (`/docs/advisory/v1.0-draft/`, `/docs/diabetes/v1.0-draft/`, `/docs/genomics/v1/`) that were renamed away and had been returning 404. All five drafts now point at their published `/docs/{vocab}/v1-draft/` page.
+
+Per-vocab: advisory 1.0-draft.0.2, diabetes 1.0-draft.0.2, evidence 1.0-draft.0.3, genomics 1.0-draft.0.5, workbench 1.0-draft.0.7. None of these vocabularies is in `VOCAB_VERSIONS`, so no downstream version registry changes.
+
+---
+
 ## 2026-08-14: Four rulings — check the unchecked, keep what was dropped, canonicalize identity inputs (core v3.6, health v2.7, clinical v1.15)
 
 Four independent findings, authored together because three of them touch the same two property shapes and the fourth is what makes those shapes reachable by real converted data. All of it is additive and strictly widening: every graph that validated before validates now, at the same severity, with one deliberate new finding at `sh:Warning` only.

--- a/ontologies/advisory/v1-draft/advisory.ttl
+++ b/ontologies/advisory/v1-draft/advisory.ttl
@@ -8,9 +8,17 @@
 @prefix dct:      <http://purl.org/dc/terms/> .
 @prefix prov:     <http://www.w3.org/ns/prov#> .
 
+@prefix vs:       <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 # ============================================================================
 # Changelog
 # ============================================================================
+# v1.0-draft.0.2 (2026-08-20) — Per-term maturity. Every term now carries
+#   vs:term_status (W3C SemWeb Vocabulary Status, originating in FOAF):
+#   "unstable" for draft terms, "archaic" for terms already marked
+#   owl:deprecated. The convention is per-TERM by design, so a vocabulary
+#   can promote individual terms in place without a namespace change;
+#   Cascade previously stated maturity once per vocabulary, in prose no
+#   machine could read. No term definition changed.
 # v1.0-draft.0.1 (2026-05-05) — Initial draft.
 #   Defines the Cascade Advisory Patch (CAP) profile envelope, the six
 #   AdvisoryClass named individuals, the Cadence enum, the per-pod
@@ -30,10 +38,10 @@
     dct:description "Vocabulary for the Cascade Advisory Patch (CAP) profile — a constrained subset of W3C LDPatch carrying clinical knowledge updates (variant reclassifications, PGx dosing changes, surveillance guideline updates, etc.) into a Cascade pod with author-readable, statically-auditable, bounded-execution semantics."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-05-05"^^xsd:date ;
-    dct:modified "2026-05-05"^^xsd:date ;
-    owl:versionInfo "1.0-draft" ;
+    dct:modified "2026-08-20"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.2" ;
     rdfs:comment "DRAFT — vocabulary is under development and subject to change before v1.0 stable release. Architecture: (1) constrained-LDPatch envelope (advisory:CascadeAdvisoryPatch) with required human-readable summary, advisory class, issuer, and issuance time; (2) tiered cadence — SafetyCritical advisories check on every app open, VariantReclassification monthly, SurveillanceGuidelineUpdate quarterly-to-annual (advisory:Cadence enum); (3) per-pod trust — each pod chooses which issuers to trust via advisory:TrustedIssuer records (advisory:TrustSourceEnum tracks how each was added: cascade-cli starter list vs user-added vs imported-from-registry vs verified-via-DID); (4) detached JWS Ed25519 signatures (RFC 7515) for issuer authentication (advisory:signature plus issuer claims); (5) opt-in auto-apply scoped per (issuer x advisoryClass) pair via advisory:AutoApplyPolicy. The application of an advisory to a pod is recorded using cascade:AdvisoryApplicationActivity (declared in core v3.1, not redeclared here)."@en ;
-    rdfs:seeAlso <https://cascadeprotocol.org/docs/advisory/v1.0-draft/> .
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/advisory/v1-draft/> .
 
 # ============================================================================
 # Profile envelope: CascadeAdvisoryPatch
@@ -42,7 +50,8 @@
 advisory:CascadeAdvisoryPatch a owl:Class ;
     rdfs:label "Cascade Advisory Patch"@en ;
     rdfs:comment "The envelope of a CAP file — a constrained-LDPatch document delivering a clinical knowledge update to a Cascade pod. Subclass of prov:Entity so applications can be linked via prov:used / prov:wasGeneratedBy. The application of a CAP to a pod is recorded as a cascade:AdvisoryApplicationActivity (defined in core v3.1) which uses prov:used to point at both the patch and the matched record. Every CascadeAdvisoryPatch MUST carry advisory:humanSummary, advisory:advisoryClass, advisory:issuer, and advisory:issuedAt; SHOULD carry advisory:signature; MAY carry advisory:supersedes, advisory:applicableUntil, advisory:advisoryId, advisory:issuerName, advisory:evidenceUrl, advisory:profileVersion, and advisory:appliesToActiveOnly."@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 # ----------------------------------------------------------------------------
 # Required envelope properties
@@ -52,24 +61,28 @@ advisory:humanSummary a owl:DatatypeProperty ;
     rdfs:label "Human Summary"@en ;
     rdfs:comment "Plain-text, one-paragraph, patient-readable summary of what this advisory means and what (if anything) the user should do. REQUIRED on every advisory — the applier MUST reject patches without it. This is the string the queue UI shows the user when prompting for approval."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 advisory:advisoryClass a owl:ObjectProperty ;
     rdfs:label "Advisory Class"@en ;
     rdfs:comment "The taxonomic category of this advisory, drawn from the six published advisory:AdvisoryClass named individuals. Drives the cadence with which the pod checks for new advisories of this class and the default queue-vs-auto-apply behaviour."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range advisory:AdvisoryClass .
+    rdfs:range advisory:AdvisoryClass ;
+    vs:term_status "unstable" .
 
 advisory:issuer a owl:ObjectProperty ;
     rdfs:label "Issuer"@en ;
     rdfs:comment "The IRI (or DID) identifying the entity that signed this advisory. The pod compares this to its local advisory:TrustedIssuer graph to decide whether to honour the patch silently, queue it for explicit user trust review, or reject it. Range is advisory:TrustedIssuer when the issuer record has been resolved into the pod; xsd:anyURI when the patch is being parsed before resolution."@en ;
-    rdfs:domain advisory:CascadeAdvisoryPatch .
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    vs:term_status "unstable" .
 
 advisory:issuedAt a owl:DatatypeProperty ;
     rdfs:label "Issued At"@en ;
     rdfs:comment "ISO 8601 dateTime when the issuer signed this advisory. REQUIRED. Used both for ordering (later issuance supersedes earlier in a chain) and for signature freshness checks."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 # ----------------------------------------------------------------------------
 # Optional envelope properties
@@ -78,48 +91,56 @@ advisory:issuedAt a owl:DatatypeProperty ;
 advisory:advisoryId a owl:ObjectProperty ;
     rdfs:label "Advisory Identifier"@en ;
     rdfs:comment "Stable identifier IRI for this specific advisory. Used as the target of advisory:supersedes in later advisories that revise or replace this one. Optional but strongly recommended for any advisory that may be superseded later."@en ;
-    rdfs:domain advisory:CascadeAdvisoryPatch .
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    vs:term_status "unstable" .
 
 advisory:supersedes a owl:ObjectProperty ;
     rdfs:label "Supersedes"@en ;
     rdfs:comment "IRI of a prior advisory:CascadeAdvisoryPatch that this one revises or replaces. Forms a supersession chain. The pod MAY mark records produced by the prior advisory as superseded but MUST NOT delete them — supersession is monotonic and roll-forward auditable per CAP profile constraint C1."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range advisory:CascadeAdvisoryPatch .
+    rdfs:range advisory:CascadeAdvisoryPatch ;
+    vs:term_status "unstable" .
 
 advisory:applicableUntil a owl:DatatypeProperty ;
     rdfs:label "Applicable Until"@en ;
     rdfs:comment "ISO 8601 dateTime after which this advisory should no longer be applied to new matches. The pod SHOULD still honour applications that occurred before this time. Used by both worked examples (BRCA2 reclassification, CPIC CYP2C19/warfarin) — the canonical name."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 advisory:profileVersion a owl:DatatypeProperty ;
     rdfs:label "Profile Version"@en ;
     rdfs:comment "Version of the Cascade Advisory Patch profile this advisory conforms to (e.g. \"0.1\"). Lets the applier reject patches written against a profile version it does not implement."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 advisory:issuerName a owl:DatatypeProperty ;
     rdfs:label "Issuer Display Name"@en ;
     rdfs:comment "Human-readable display name for the issuer (e.g. \"ClinGen HBOP-VCEP\", \"CPIC\"). Convenience field for UI; the authoritative identity is advisory:issuer."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 advisory:evidenceUrl a owl:ObjectProperty ;
     rdfs:label "Evidence URL"@en ;
     rdfs:comment "IRI of the publicly-citable evidence supporting this advisory (a ClinVar evidence-repo entry, a CPIC guideline page, a published VCEP statement, etc.). Shown to the user in the queue UI as a 'learn more' link."@en ;
-    rdfs:domain advisory:CascadeAdvisoryPatch .
+    rdfs:domain advisory:CascadeAdvisoryPatch ;
+    vs:term_status "unstable" .
 
 advisory:appliesToActiveOnly a owl:DatatypeProperty ;
     rdfs:label "Applies To Active Records Only"@en ;
     rdfs:comment "If true, the advisory should only fire when the matched record is currently 'active' according to the pod's domain semantics (e.g. a medication still on the active list, a condition not marked resolved). Used in PGx dosing advisories so the pod does not re-surface guidance for drugs the user discontinued."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+    vs:term_status "unstable" .
 
 advisory:cadence a owl:ObjectProperty ;
     rdfs:label "Cadence"@en ;
     rdfs:comment "Optional override of the default check-cadence for this advisory class. If absent, the pod uses the cadence implied by advisory:advisoryClass."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range advisory:Cadence .
+    rdfs:range advisory:Cadence ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Signature (per D-Q4: detached JWS Ed25519, RFC 7515)
@@ -129,31 +150,36 @@ advisory:signature a owl:DatatypeProperty ;
     rdfs:label "Signature"@en ;
     rdfs:comment "Detached JWS in RFC 7515 compact serialization carrying an Ed25519 signature over the canonicalized patch body. The protected header MUST include the JWS claims advisory:signatureIssuer (iss), advisory:signatureIssuedAt (iat), and advisory:signatureContentType (cty, fixed to 'application/x-cascade-advisory-patch'); MAY include advisory:signatureExpiresAt (exp). The signature is verified against the public key on the matching advisory:TrustedIssuer record. Per D-Q4, W3C VC 2.0 envelope wrapping is deferred to a later profile version."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 advisory:signatureIssuer a owl:DatatypeProperty ;
     rdfs:label "Signature Issuer (iss)"@en ;
     rdfs:comment "JWS 'iss' claim — the issuer URI asserted inside the signed envelope. The applier MUST verify this matches advisory:issuer on the unsigned envelope."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 advisory:signatureIssuedAt a owl:DatatypeProperty ;
     rdfs:label "Signature Issued At (iat)"@en ;
     rdfs:comment "JWS 'iat' claim — Unix epoch seconds at which the signature was produced. The applier MUST verify this is consistent with advisory:issuedAt within an implementation-defined skew tolerance."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:long .
+    rdfs:range xsd:long ;
+    vs:term_status "unstable" .
 
 advisory:signatureExpiresAt a owl:DatatypeProperty ;
     rdfs:label "Signature Expires At (exp)"@en ;
     rdfs:comment "JWS 'exp' claim — Unix epoch seconds after which the signature itself is no longer valid (independent of advisory:applicableUntil, which scopes the clinical applicability)."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:long .
+    rdfs:range xsd:long ;
+    vs:term_status "unstable" .
 
 advisory:signatureContentType a owl:DatatypeProperty ;
     rdfs:label "Signature Content Type (cty)"@en ;
     rdfs:comment "JWS 'cty' claim — fixed to 'application/x-cascade-advisory-patch' for v0.1. Lets generic JWS verifiers reject signatures intended for other media types."@en ;
     rdfs:domain advisory:CascadeAdvisoryPatch ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # AdvisoryClass taxonomy (six named individuals)
@@ -167,31 +193,38 @@ advisory:signatureContentType a owl:DatatypeProperty ;
 
 advisory:AdvisoryClass a owl:Class ;
     rdfs:label "Advisory Class"@en ;
-    rdfs:comment "Closed taxonomy of advisory categories. The class drives the recommended check cadence and the default queue-vs-auto-apply UX. v0.1 ships six named individuals; new classes require a vocabulary version bump."@en .
+    rdfs:comment "Closed taxonomy of advisory categories. The class drives the recommended check cadence and the default queue-vs-auto-apply UX. v0.1 ships six named individuals; new classes require a vocabulary version bump."@en ;
+    vs:term_status "unstable" .
 
 advisory:SafetyCritical a owl:NamedIndividual, advisory:AdvisoryClass ;
     rdfs:label "Safety-Critical"@en ;
-    rdfs:comment "An advisory that, if not surfaced quickly, may put the user at material clinical risk (e.g. a drug recall, a black-box warning added to a medication the user is taking, an urgent revocation of a prior reclassification). Recommended cadence: every app open. Default UX: surface as an in-app banner immediately on next open; do not silently auto-apply unless the user has explicitly opted in for this issuer."@en .
+    rdfs:comment "An advisory that, if not surfaced quickly, may put the user at material clinical risk (e.g. a drug recall, a black-box warning added to a medication the user is taking, an urgent revocation of a prior reclassification). Recommended cadence: every app open. Default UX: surface as an in-app banner immediately on next open; do not silently auto-apply unless the user has explicitly opted in for this issuer."@en ;
+    vs:term_status "unstable" .
 
 advisory:VariantReclassification a owl:NamedIndividual, advisory:AdvisoryClass ;
     rdfs:label "Variant Reclassification"@en ;
-    rdfs:comment "An advisory that updates the ACMG (or comparable) clinical classification of a previously interpreted variant — typically VUS to Likely Pathogenic, Likely Pathogenic to Pathogenic, or downgrade in the opposite direction. Recommended cadence: monthly. Default UX: queue for user review with the prior interpretation shown alongside the proposed new one; encourage re-engagement with a genetic counselor."@en .
+    rdfs:comment "An advisory that updates the ACMG (or comparable) clinical classification of a previously interpreted variant — typically VUS to Likely Pathogenic, Likely Pathogenic to Pathogenic, or downgrade in the opposite direction. Recommended cadence: monthly. Default UX: queue for user review with the prior interpretation shown alongside the proposed new one; encourage re-engagement with a genetic counselor."@en ;
+    vs:term_status "unstable" .
 
 advisory:DrugInteraction a owl:NamedIndividual, advisory:AdvisoryClass ;
     rdfs:label "Drug Interaction / PGx Update"@en ;
-    rdfs:comment "An advisory carrying new or updated pharmacogenetic dosing guidance (e.g. CPIC-style guideline revisions tied to a star allele or diplotype). Recommended cadence: monthly. Default UX: queue for review when the relevant medication is on the user's active list; suppress when not (see advisory:appliesToActiveOnly)."@en .
+    rdfs:comment "An advisory carrying new or updated pharmacogenetic dosing guidance (e.g. CPIC-style guideline revisions tied to a star allele or diplotype). Recommended cadence: monthly. Default UX: queue for review when the relevant medication is on the user's active list; suppress when not (see advisory:appliesToActiveOnly)."@en ;
+    vs:term_status "unstable" .
 
 advisory:LabReferenceRangeUpdate a owl:NamedIndividual, advisory:AdvisoryClass ;
     rdfs:label "Lab Reference Range Update"@en ;
-    rdfs:comment "An advisory that updates the reference range, units, or interpretation thresholds for a lab analyte (e.g. a new age-specific HbA1c band, a unit harmonization). Recommended cadence: quarterly. Default UX: silent auto-apply when the issuer is on the auto-apply policy for this class, since the change is typically a non-clinical re-display."@en .
+    rdfs:comment "An advisory that updates the reference range, units, or interpretation thresholds for a lab analyte (e.g. a new age-specific HbA1c band, a unit harmonization). Recommended cadence: quarterly. Default UX: silent auto-apply when the issuer is on the auto-apply policy for this class, since the change is typically a non-clinical re-display."@en ;
+    vs:term_status "unstable" .
 
 advisory:SurveillanceGuidelineUpdate a owl:NamedIndividual, advisory:AdvisoryClass ;
     rdfs:label "Surveillance Guideline Update"@en ;
-    rdfs:comment "An advisory carrying changes to recommended surveillance protocols (e.g. NCCN updating screening intervals for BRCA1/2 carriers, ACMG secondary-finding actionability list edits). Recommended cadence: quarterly to annual. Default UX: queue for review and link to the published guideline."@en .
+    rdfs:comment "An advisory carrying changes to recommended surveillance protocols (e.g. NCCN updating screening intervals for BRCA1/2 carriers, ACMG secondary-finding actionability list edits). Recommended cadence: quarterly to annual. Default UX: queue for review and link to the published guideline."@en ;
+    vs:term_status "unstable" .
 
 advisory:CarrierFrequencyUpdate a owl:NamedIndividual, advisory:AdvisoryClass ;
     rdfs:label "Carrier Frequency Update"@en ;
-    rdfs:comment "An advisory updating population carrier-frequency or allele-frequency estimates used in residual-risk calculations (e.g. gnomAD release deltas, ancestry-specific frequency revisions). Recommended cadence: annual. Default UX: silent auto-apply when the issuer is on the auto-apply policy, since these are population-level reference-data refreshes."@en .
+    rdfs:comment "An advisory updating population carrier-frequency or allele-frequency estimates used in residual-risk calculations (e.g. gnomAD release deltas, ancestry-specific frequency revisions). Recommended cadence: annual. Default UX: silent auto-apply when the issuer is on the auto-apply policy, since these are population-level reference-data refreshes."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Cadence enum
@@ -199,31 +232,38 @@ advisory:CarrierFrequencyUpdate a owl:NamedIndividual, advisory:AdvisoryClass ;
 
 advisory:Cadence a owl:Class ;
     rdfs:label "Cadence"@en ;
-    rdfs:comment "Closed enumeration of recommended check-cadence values for advisories. Used as the range of advisory:cadence on a CascadeAdvisoryPatch (per-advisory override) and as the implied cadence of each advisory:AdvisoryClass."@en .
+    rdfs:comment "Closed enumeration of recommended check-cadence values for advisories. Used as the range of advisory:cadence on a CascadeAdvisoryPatch (per-advisory override) and as the implied cadence of each advisory:AdvisoryClass."@en ;
+    vs:term_status "unstable" .
 
 advisory:EveryAppOpen a owl:NamedIndividual, advisory:Cadence ;
     rdfs:label "Every App Open"@en ;
-    rdfs:comment "Pod checks for new advisories of this class on every foregrounding of the app. Reserved for SafetyCritical."@en .
+    rdfs:comment "Pod checks for new advisories of this class on every foregrounding of the app. Reserved for SafetyCritical."@en ;
+    vs:term_status "unstable" .
 
 advisory:Daily a owl:NamedIndividual, advisory:Cadence ;
     rdfs:label "Daily"@en ;
-    rdfs:comment "Pod checks at most once per calendar day."@en .
+    rdfs:comment "Pod checks at most once per calendar day."@en ;
+    vs:term_status "unstable" .
 
 advisory:Weekly a owl:NamedIndividual, advisory:Cadence ;
     rdfs:label "Weekly"@en ;
-    rdfs:comment "Pod checks at most once per calendar week."@en .
+    rdfs:comment "Pod checks at most once per calendar week."@en ;
+    vs:term_status "unstable" .
 
 advisory:Monthly a owl:NamedIndividual, advisory:Cadence ;
     rdfs:label "Monthly"@en ;
-    rdfs:comment "Pod checks at most once per calendar month. Default cadence for VariantReclassification and DrugInteraction."@en .
+    rdfs:comment "Pod checks at most once per calendar month. Default cadence for VariantReclassification and DrugInteraction."@en ;
+    vs:term_status "unstable" .
 
 advisory:Quarterly a owl:NamedIndividual, advisory:Cadence ;
     rdfs:label "Quarterly"@en ;
-    rdfs:comment "Pod checks at most once per calendar quarter. Default cadence for LabReferenceRangeUpdate and the lower bound for SurveillanceGuidelineUpdate."@en .
+    rdfs:comment "Pod checks at most once per calendar quarter. Default cadence for LabReferenceRangeUpdate and the lower bound for SurveillanceGuidelineUpdate."@en ;
+    vs:term_status "unstable" .
 
 advisory:Annually a owl:NamedIndividual, advisory:Cadence ;
     rdfs:label "Annually"@en ;
-    rdfs:comment "Pod checks at most once per calendar year. Default cadence for CarrierFrequencyUpdate and the upper bound for SurveillanceGuidelineUpdate."@en .
+    rdfs:comment "Pod checks at most once per calendar year. Default cadence for CarrierFrequencyUpdate and the upper bound for SurveillanceGuidelineUpdate."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # TrustedIssuer (per D-Q3: per-pod, lives in <pod>/trust/issuers.ttl)
@@ -231,57 +271,68 @@ advisory:Annually a owl:NamedIndividual, advisory:Cadence ;
 
 advisory:TrustedIssuer a owl:Class ;
     rdfs:label "Trusted Issuer"@en ;
-    rdfs:comment "An issuer the pod has chosen to trust. Lives per-pod (typically at <pod>/trust/issuers.ttl) — the protocol does NOT define a centralized registry. How the pod populates this graph (cascade-cli starter list, user-added in-app, imported from a community-driven registry URL, or verified via DID) is operational and is captured per-record by advisory:trustSource. Per D-Q3 the protocol is positioned as an extensible framework rather than a gatekeeper; community-driven issuer evaluation and certification is a separate, parallel workstream."@en .
+    rdfs:comment "An issuer the pod has chosen to trust. Lives per-pod (typically at <pod>/trust/issuers.ttl) — the protocol does NOT define a centralized registry. How the pod populates this graph (cascade-cli starter list, user-added in-app, imported from a community-driven registry URL, or verified via DID) is operational and is captured per-record by advisory:trustSource. Per D-Q3 the protocol is positioned as an extensible framework rather than a gatekeeper; community-driven issuer evaluation and certification is a separate, parallel workstream."@en ;
+    vs:term_status "unstable" .
 
 advisory:trustedIssuerId a owl:DatatypeProperty ;
     rdfs:label "Trusted Issuer Identifier"@en ;
     rdfs:comment "The IRI (HTTPS URL or DID) that uniquely identifies this issuer. MUST equal the value of advisory:issuer on any patch this issuer signs."@en ;
     rdfs:domain advisory:TrustedIssuer ;
-    rdfs:range xsd:anyURI .
+    rdfs:range xsd:anyURI ;
+    vs:term_status "unstable" .
 
 advisory:trustedIssuerName a owl:DatatypeProperty ;
     rdfs:label "Trusted Issuer Display Name"@en ;
     rdfs:comment "Human-readable name shown in pod UI when describing this issuer (e.g. 'ClinGen HBOP-VCEP', 'CPIC')."@en ;
     rdfs:domain advisory:TrustedIssuer ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 advisory:trustedIssuerPublicKey a owl:DatatypeProperty ;
     rdfs:label "Trusted Issuer Public Key"@en ;
     rdfs:comment "The Ed25519 public key (per D-Q4) used to verify advisory:signature on patches issued by this issuer. Encoded as a JWK (RFC 7517) JSON string or as multibase-encoded raw key bytes; SHACL shapes constrain the exact form."@en ;
     rdfs:domain advisory:TrustedIssuer ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 advisory:trustSource a owl:ObjectProperty ;
     rdfs:label "Trust Source"@en ;
     rdfs:comment "Provenance flag indicating how this issuer was added to the pod's trust graph. Used by UI to differentiate cascade-recommended starters from user-curated additions and to surface 'imported from community registry' provenance."@en ;
     rdfs:domain advisory:TrustedIssuer ;
-    rdfs:range advisory:TrustSourceEnum .
+    rdfs:range advisory:TrustSourceEnum ;
+    vs:term_status "unstable" .
 
 advisory:trustAddedAt a owl:DatatypeProperty ;
     rdfs:label "Trust Added At"@en ;
     rdfs:comment "ISO 8601 dateTime when this issuer was added to the pod's trust graph."@en ;
     rdfs:domain advisory:TrustedIssuer ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 advisory:TrustSourceEnum a owl:Class ;
     rdfs:label "Trust Source Enumeration"@en ;
-    rdfs:comment "Closed enumeration of the ways an advisory:TrustedIssuer record may have entered the pod's trust graph."@en .
+    rdfs:comment "Closed enumeration of the ways an advisory:TrustedIssuer record may have entered the pod's trust graph."@en ;
+    vs:term_status "unstable" .
 
 advisory:RecommendedStarterList a owl:NamedIndividual, advisory:TrustSourceEnum ;
     rdfs:label "Recommended Starter List"@en ;
-    rdfs:comment "Issuer was seeded by `cascade-cli init` from the cascade-recommended starter list (e.g. ClinGen, CPIC, NCCN). The list is a non-binding suggestion; the user retains authority to remove any of these issuers."@en .
+    rdfs:comment "Issuer was seeded by `cascade-cli init` from the cascade-recommended starter list (e.g. ClinGen, CPIC, NCCN). The list is a non-binding suggestion; the user retains authority to remove any of these issuers."@en ;
+    vs:term_status "unstable" .
 
 advisory:UserAdded a owl:NamedIndividual, advisory:TrustSourceEnum ;
     rdfs:label "User Added"@en ;
-    rdfs:comment "Issuer was explicitly added by the user in-app, typically by pasting an issuer URI or scanning a QR code provided by the issuer."@en .
+    rdfs:comment "Issuer was explicitly added by the user in-app, typically by pasting an issuer URI or scanning a QR code provided by the issuer."@en ;
+    vs:term_status "unstable" .
 
 advisory:ImportedFromRegistry a owl:NamedIndividual, advisory:TrustSourceEnum ;
     rdfs:label "Imported From Registry"@en ;
-    rdfs:comment "Issuer was imported from a community-driven issuer registry URL the user chose to consult. Forward-compatibility hook for the parallel issuer-certification workstream."@en .
+    rdfs:comment "Issuer was imported from a community-driven issuer registry URL the user chose to consult. Forward-compatibility hook for the parallel issuer-certification workstream."@en ;
+    vs:term_status "unstable" .
 
 advisory:VerifiedViaDID a owl:NamedIndividual, advisory:TrustSourceEnum ;
     rdfs:label "Verified Via DID"@en ;
-    rdfs:comment "Issuer identifier was resolved as a Decentralized Identifier and the DID document chain was verified at trust-add time. Forward-compatibility hook for DID-based issuer identity."@en .
+    rdfs:comment "Issuer identifier was resolved as a Decentralized Identifier and the DID document chain was verified at trust-add time. Forward-compatibility hook for DID-based issuer identity."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # AutoApplyPolicy
@@ -289,47 +340,55 @@ advisory:VerifiedViaDID a owl:NamedIndividual, advisory:TrustSourceEnum ;
 
 advisory:AutoApplyPolicy a owl:Class ;
     rdfs:label "Auto-Apply Policy"@en ;
-    rdfs:comment "A per-pod policy declaring which (issuer x advisoryClass) pairs the pod will apply silently rather than queueing for explicit user approval. Auto-apply is opt-in by default; the user adds policy records explicitly. Each record points at one or more advisory:AutoApplyScope tuples."@en .
+    rdfs:comment "A per-pod policy declaring which (issuer x advisoryClass) pairs the pod will apply silently rather than queueing for explicit user approval. Auto-apply is opt-in by default; the user adds policy records explicitly. Each record points at one or more advisory:AutoApplyScope tuples."@en ;
+    vs:term_status "unstable" .
 
 advisory:appliesTo a owl:ObjectProperty ;
     rdfs:label "Applies To (Auto-Apply Scope)"@en ;
     rdfs:comment "Links a policy to one or more advisory:AutoApplyScope records, each pairing an issuer with an advisory class. A patch matches the policy when its (advisory:issuer, advisory:advisoryClass) tuple equals at least one of the linked scopes."@en ;
     rdfs:domain advisory:AutoApplyPolicy ;
-    rdfs:range advisory:AutoApplyScope .
+    rdfs:range advisory:AutoApplyScope ;
+    vs:term_status "unstable" .
 
 advisory:effectiveFrom a owl:DatatypeProperty ;
     rdfs:label "Effective From"@en ;
     rdfs:comment "ISO 8601 dateTime from which the policy is active. Patches issued or applied before this time fall back to queue-for-approval."@en ;
     rdfs:domain advisory:AutoApplyPolicy ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 advisory:effectiveUntil a owl:DatatypeProperty ;
     rdfs:label "Effective Until"@en ;
     rdfs:comment "ISO 8601 dateTime after which the policy is no longer active. Optional — absence means the policy stays active until the user revokes it."@en ;
     rdfs:domain advisory:AutoApplyPolicy ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 advisory:requiresQuorum a owl:DatatypeProperty ;
     rdfs:label "Requires Quorum"@en ;
     rdfs:comment "Forward-compatibility flag for v1.0 counter-signing. When true, the policy will only auto-apply if the patch carries signatures from a quorum of trusted issuers (rather than just one). Declared in v0.1 for forward compatibility but unused — the v0.1 applier MUST treat this as if absent and ignore counter-signatures."@en ;
     rdfs:domain advisory:AutoApplyPolicy ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+    vs:term_status "unstable" .
 
 advisory:AutoApplyScope a owl:Class ;
     rdfs:label "Auto-Apply Scope"@en ;
-    rdfs:comment "One (issuer, advisoryClass) tuple authorizing silent auto-application. Reusable across multiple AutoApplyPolicy records."@en .
+    rdfs:comment "One (issuer, advisoryClass) tuple authorizing silent auto-application. Reusable across multiple AutoApplyPolicy records."@en ;
+    vs:term_status "unstable" .
 
 advisory:scopeIssuer a owl:ObjectProperty ;
     rdfs:label "Scope Issuer"@en ;
     rdfs:comment "The trusted issuer this scope authorizes."@en ;
     rdfs:domain advisory:AutoApplyScope ;
-    rdfs:range advisory:TrustedIssuer .
+    rdfs:range advisory:TrustedIssuer ;
+    vs:term_status "unstable" .
 
 advisory:scopeAdvisoryClass a owl:ObjectProperty ;
     rdfs:label "Scope Advisory Class"@en ;
     rdfs:comment "The advisory class this scope authorizes for the paired issuer. Use one of the six published advisory:AdvisoryClass named individuals."@en ;
     rdfs:domain advisory:AutoApplyScope ;
-    rdfs:range advisory:AdvisoryClass .
+    rdfs:range advisory:AdvisoryClass ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Cross-references (declared in core v3.1, NOT redeclared here)

--- a/ontologies/diabetes/v1-draft/diabetes.ttl
+++ b/ontologies/diabetes/v1-draft/diabetes.ttl
@@ -11,6 +11,18 @@
 @prefix ucum: <http://unitsofmeasure.org/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
+@prefix vs:       <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+# ============================================================================
+# Changelog
+# ============================================================================
+# v1.0-draft.0.2 (2026-08-20) — Per-term maturity. Every term now carries
+#   vs:term_status (W3C SemWeb Vocabulary Status, originating in FOAF):
+#   "unstable" for draft terms, "archaic" for terms already marked
+#   owl:deprecated. The convention is per-TERM by design, so a vocabulary
+#   can promote individual terms in place without a namespace change;
+#   Cascade previously stated maturity once per vocabulary, in prose no
+#   machine could read. No term definition changed.
+
 # ============================================================================
 # Ontology Metadata
 # ============================================================================
@@ -21,9 +33,10 @@
     dct:description "Unified vocabulary for diabetes and pre-diabetes management, aggregating data from CGMs, glucose meters, insulin delivery systems, and lifestyle tracking devices"@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2025-12-12"^^xsd:date ;
-    owl:versionInfo "1.0-draft" ;
+    dct:modified "2026-08-20"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.2" ;
     rdfs:comment "DRAFT - This vocabulary is under development and subject to change. Domain-specific vocabulary for diabetes wellness tracking. Designed to unify data from multiple wearables and apps into a coherent, analyzable format."@en ;
-    rdfs:seeAlso <https://cascadeprotocol.org/docs/diabetes/v1.0-draft/> .
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/diabetes/v1-draft/> .
 
 # ============================================================================
 # Diabetes Classification
@@ -31,7 +44,8 @@
 
 diabetes:DiabetesType a owl:Class ;
     rdfs:label "Diabetes Type"@en ;
-    rdfs:comment "Classification of diabetes or metabolic condition"@en .
+    rdfs:comment "Classification of diabetes or metabolic condition"@en ;
+    vs:term_status "unstable" .
 
 diabetes:Type1 a diabetes:DiabetesType ;
     rdfs:label "Type 1 Diabetes"@en ;
@@ -65,11 +79,13 @@ diabetes:GlucoseReading a owl:Class ;
     rdfs:label "Glucose Reading"@en ;
     rdfs:comment "Single blood glucose measurement from any source (CGM, finger stick, lab)"@en ;
     rdfs:subClassOf fhir:Observation ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:GlucoseMeasurementType a owl:Class ;
     rdfs:label "Glucose Measurement Type"@en ;
-    rdfs:comment "Classification of glucose measurement method"@en .
+    rdfs:comment "Classification of glucose measurement method"@en ;
+    vs:term_status "unstable" .
 
 diabetes:CGMReading a diabetes:GlucoseMeasurementType ;
     rdfs:label "Continuous Glucose Monitor"@en ;
@@ -92,37 +108,43 @@ diabetes:glucoseValue a owl:DatatypeProperty ;
     rdfs:comment "Glucose concentration (see glucoseUnit for measurement unit)"@en ;
     rdfs:domain diabetes:GlucoseReading ;
     rdfs:range xsd:double ;
-    owl:equivalentProperty loinc:15074-8 .
+    owl:equivalentProperty loinc:15074-8 ;
+    vs:term_status "unstable" .
 
 diabetes:glucoseUnit a owl:DatatypeProperty ;
     rdfs:label "Glucose Unit"@en ;
     rdfs:comment "Unit of measurement: 'mg/dL' (US) or 'mmol/L' (international)"@en ;
     rdfs:domain diabetes:GlucoseReading ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:measurementType a owl:ObjectProperty ;
     rdfs:label "Measurement Type"@en ;
     rdfs:comment "Method used to obtain glucose reading"@en ;
     rdfs:domain diabetes:GlucoseReading ;
-    rdfs:range diabetes:GlucoseMeasurementType .
+    rdfs:range diabetes:GlucoseMeasurementType ;
+    vs:term_status "unstable" .
 
 diabetes:measurementTimestamp a owl:DatatypeProperty ;
     rdfs:label "Measurement Timestamp"@en ;
     rdfs:comment "ISO 8601 timestamp when reading was taken"@en ;
     rdfs:domain diabetes:GlucoseReading ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 diabetes:trendArrow a owl:DatatypeProperty ;
     rdfs:label "Trend Arrow"@en ;
     rdfs:comment "CGM trend indicator: rapidlyFalling, falling, steady, rising, rapidlyRising"@en ;
     rdfs:domain diabetes:GlucoseReading ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:trendRate a owl:DatatypeProperty ;
     rdfs:label "Trend Rate"@en ;
     rdfs:comment "Rate of glucose change (mg/dL/min or mmol/L/min)"@en ;
     rdfs:domain diabetes:GlucoseReading ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # CGM Session
@@ -131,36 +153,42 @@ diabetes:trendRate a owl:DatatypeProperty ;
 diabetes:CGMSession a owl:Class ;
     rdfs:label "CGM Session"@en ;
     rdfs:comment "A continuous glucose monitoring session (typically 10-14 days per sensor)"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:sensorType a owl:DatatypeProperty ;
     rdfs:label "Sensor Type"@en ;
     rdfs:comment "CGM sensor model (e.g., 'Dexcom G7', 'Freestyle Libre 3')"@en ;
     rdfs:domain diabetes:CGMSession ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:sensorSerialNumber a owl:DatatypeProperty ;
     rdfs:label "Sensor Serial Number"@en ;
     rdfs:domain diabetes:CGMSession ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:sessionStart a owl:DatatypeProperty ;
     rdfs:label "Session Start"@en ;
     rdfs:comment "Timestamp when sensor was applied/activated"@en ;
     rdfs:domain diabetes:CGMSession ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 diabetes:sessionEnd a owl:DatatypeProperty ;
     rdfs:label "Session End"@en ;
     rdfs:comment "Timestamp when sensor expired or was removed"@en ;
     rdfs:domain diabetes:CGMSession ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 diabetes:sensorWearLocation a owl:DatatypeProperty ;
     rdfs:label "Sensor Wear Location"@en ;
     rdfs:comment "Body location: abdomen, arm, thigh, etc."@en ;
     rdfs:domain diabetes:CGMSession ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Insulin Delivery
@@ -170,11 +198,13 @@ diabetes:InsulinDose a owl:Class ;
     rdfs:label "Insulin Dose"@en ;
     rdfs:comment "Record of insulin delivery from pump, pen, or injection"@en ;
     rdfs:subClassOf fhir:MedicationAdministration ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:InsulinType a owl:Class ;
     rdfs:label "Insulin Type"@en ;
-    rdfs:comment "Classification of insulin by action profile"@en .
+    rdfs:comment "Classification of insulin by action profile"@en ;
+    vs:term_status "unstable" .
 
 diabetes:RapidActing a diabetes:InsulinType ;
     rdfs:label "Rapid Acting"@en ;
@@ -194,7 +224,8 @@ diabetes:LongActing a diabetes:InsulinType ;
 
 diabetes:DoseType a owl:Class ;
     rdfs:label "Dose Type"@en ;
-    rdfs:comment "Purpose of insulin dose"@en .
+    rdfs:comment "Purpose of insulin dose"@en ;
+    vs:term_status "unstable" .
 
 diabetes:Bolus a diabetes:DoseType ;
     rdfs:label "Bolus"@en ;
@@ -213,35 +244,41 @@ diabetes:insulinUnits a owl:DatatypeProperty ;
     rdfs:label "Insulin Units"@en ;
     rdfs:comment "Amount of insulin delivered in units"@en ;
     rdfs:domain diabetes:InsulinDose ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:insulinType a owl:ObjectProperty ;
     rdfs:label "Insulin Type"@en ;
     rdfs:domain diabetes:InsulinDose ;
-    rdfs:range diabetes:InsulinType .
+    rdfs:range diabetes:InsulinType ;
+    vs:term_status "unstable" .
 
 diabetes:doseType a owl:ObjectProperty ;
     rdfs:label "Dose Type"@en ;
     rdfs:domain diabetes:InsulinDose ;
-    rdfs:range diabetes:DoseType .
+    rdfs:range diabetes:DoseType ;
+    vs:term_status "unstable" .
 
 diabetes:insulinBrand a owl:DatatypeProperty ;
     rdfs:label "Insulin Brand"@en ;
     rdfs:comment "Specific insulin product (e.g., 'Humalog', 'Tresiba')"@en ;
     rdfs:domain diabetes:InsulinDose ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:deliveryMethod a owl:DatatypeProperty ;
     rdfs:label "Delivery Method"@en ;
     rdfs:comment "How insulin was delivered: pump, pen, syringe"@en ;
     rdfs:domain diabetes:InsulinDose ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:deliveryDevice a owl:DatatypeProperty ;
     rdfs:label "Delivery Device"@en ;
     rdfs:comment "Specific device (e.g., 'Tandem t:slim X2', 'Omnipod 5')"@en ;
     rdfs:domain diabetes:InsulinDose ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Carbohydrate/Meal Tracking
@@ -250,15 +287,18 @@ diabetes:deliveryDevice a owl:DatatypeProperty ;
 diabetes:CarbEntry a owl:Class ;
     rdfs:label "Carbohydrate Entry"@en ;
     rdfs:comment "Record of carbohydrate intake for bolus calculation"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:MealEvent a owl:Class ;
     rdfs:label "Meal Event"@en ;
     rdfs:comment "Complete meal record with timing, macros, and context"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:MealType a owl:Class ;
-    rdfs:label "Meal Type"@en .
+    rdfs:label "Meal Type"@en ;
+    vs:term_status "unstable" .
 
 diabetes:Breakfast a diabetes:MealType ;
     rdfs:label "Breakfast"@en .
@@ -276,48 +316,57 @@ diabetes:Snack a diabetes:MealType ;
 diabetes:carbGrams a owl:DatatypeProperty ;
     rdfs:label "Carbohydrate Grams"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:fiberGrams a owl:DatatypeProperty ;
     rdfs:label "Fiber Grams"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:sugarGrams a owl:DatatypeProperty ;
     rdfs:label "Sugar Grams"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:proteinGrams a owl:DatatypeProperty ;
     rdfs:label "Protein Grams"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:fatGrams a owl:DatatypeProperty ;
     rdfs:label "Fat Grams"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:calories a owl:DatatypeProperty ;
     rdfs:label "Calories"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:glycemicIndex a owl:DatatypeProperty ;
     rdfs:label "Glycemic Index"@en ;
     rdfs:comment "GI value (0-100) if known"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 diabetes:foodDescription a owl:DatatypeProperty ;
     rdfs:label "Food Description"@en ;
     rdfs:domain diabetes:CarbEntry ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:mealType a owl:ObjectProperty ;
     rdfs:label "Meal Type"@en ;
     rdfs:domain diabetes:MealEvent ;
-    rdfs:range diabetes:MealType .
+    rdfs:range diabetes:MealType ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Daily Summary - Time in Range Metrics
@@ -326,112 +375,131 @@ diabetes:mealType a owl:ObjectProperty ;
 diabetes:DailyGlucoseSummary a owl:Class ;
     rdfs:label "Daily Glucose Summary"@en ;
     rdfs:comment "Aggregated glucose metrics for a single day following ADA/EASD consensus standards"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:summaryDate a owl:DatatypeProperty ;
     rdfs:label "Summary Date"@en ;
     rdfs:comment "The date this summary covers"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:date .
+    rdfs:range xsd:date ;
+    vs:term_status "unstable" .
 
 # Time in Range metrics (ADA/EASD consensus)
 diabetes:timeInRange a owl:DatatypeProperty ;
     rdfs:label "Time in Range (%)"@en ;
     rdfs:comment "Percentage of time glucose was 70-180 mg/dL (target >70%)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:timeBelowRange a owl:DatatypeProperty ;
     rdfs:label "Time Below Range (%)"@en ;
     rdfs:comment "Percentage of time glucose was <70 mg/dL (target <4%)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:timeAboveRange a owl:DatatypeProperty ;
     rdfs:label "Time Above Range (%)"@en ;
     rdfs:comment "Percentage of time glucose was >180 mg/dL (target <25%)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:timeInTightRange a owl:DatatypeProperty ;
     rdfs:label "Time in Tight Range (%)"@en ;
     rdfs:comment "Percentage of time glucose was 70-140 mg/dL (pregnancy target)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:timeSeverelyLow a owl:DatatypeProperty ;
     rdfs:label "Time Severely Low (%)"@en ;
     rdfs:comment "Percentage of time glucose was <54 mg/dL (target <1%)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:timeSeverelyHigh a owl:DatatypeProperty ;
     rdfs:label "Time Severely High (%)"@en ;
     rdfs:comment "Percentage of time glucose was >250 mg/dL (target <5%)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # Statistical metrics
 diabetes:meanGlucose a owl:DatatypeProperty ;
     rdfs:label "Mean Glucose"@en ;
     rdfs:comment "Average glucose value for the period"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:standardDeviation a owl:DatatypeProperty ;
     rdfs:label "Standard Deviation"@en ;
     rdfs:comment "Glucose variability measure (lower is more stable)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:coefficientOfVariation a owl:DatatypeProperty ;
     rdfs:label "Coefficient of Variation (%)"@en ;
     rdfs:comment "CV = SD/Mean * 100 (target <36% for stable glucose)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:gmi a owl:DatatypeProperty ;
     rdfs:label "Glucose Management Indicator"@en ;
     rdfs:comment "GMI (estimated HbA1c from CGM data): GMI = 3.31 + (0.02392 * mean glucose mg/dL)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:minGlucose a owl:DatatypeProperty ;
     rdfs:label "Minimum Glucose"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:maxGlucose a owl:DatatypeProperty ;
     rdfs:label "Maximum Glucose"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:sensorActivePercentage a owl:DatatypeProperty ;
     rdfs:label "Sensor Active (%)"@en ;
     rdfs:comment "Percentage of day with CGM data available (target >70% for valid metrics)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # Daily totals
 diabetes:totalDailyInsulin a owl:DatatypeProperty ;
     rdfs:label "Total Daily Insulin (units)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:totalBasalInsulin a owl:DatatypeProperty ;
     rdfs:label "Total Basal Insulin (units)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:totalBolusInsulin a owl:DatatypeProperty ;
     rdfs:label "Total Bolus Insulin (units)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:totalCarbs a owl:DatatypeProperty ;
     rdfs:label "Total Carbohydrates (g)"@en ;
     rdfs:domain diabetes:DailyGlucoseSummary ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Pattern Detection
@@ -440,10 +508,12 @@ diabetes:totalCarbs a owl:DatatypeProperty ;
 diabetes:GlucosePattern a owl:Class ;
     rdfs:label "Glucose Pattern"@en ;
     rdfs:comment "Identified recurring pattern in glucose data"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:PatternType a owl:Class ;
-    rdfs:label "Pattern Type"@en .
+    rdfs:label "Pattern Type"@en ;
+    vs:term_status "unstable" .
 
 diabetes:DawnPhenomenon a diabetes:PatternType ;
     rdfs:label "Dawn Phenomenon"@en ;
@@ -468,31 +538,36 @@ diabetes:InsulinSensitivityPattern a diabetes:PatternType ;
 diabetes:patternType a owl:ObjectProperty ;
     rdfs:label "Pattern Type"@en ;
     rdfs:domain diabetes:GlucosePattern ;
-    rdfs:range diabetes:PatternType .
+    rdfs:range diabetes:PatternType ;
+    vs:term_status "unstable" .
 
 diabetes:patternConfidence a owl:DatatypeProperty ;
     rdfs:label "Pattern Confidence"@en ;
     rdfs:comment "Statistical confidence in pattern detection (0.0 to 1.0)"@en ;
     rdfs:domain diabetes:GlucosePattern ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:patternTimeWindow a owl:DatatypeProperty ;
     rdfs:label "Pattern Time Window"@en ;
     rdfs:comment "Time of day pattern typically occurs (e.g., '04:00-07:00')"@en ;
     rdfs:domain diabetes:GlucosePattern ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:patternSeverity a owl:DatatypeProperty ;
     rdfs:label "Pattern Severity"@en ;
     rdfs:comment "Severity level: mild, moderate, severe"@en ;
     rdfs:domain diabetes:GlucosePattern ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:suggestedAction a owl:DatatypeProperty ;
     rdfs:label "Suggested Action"@en ;
     rdfs:comment "Recommended adjustment for discussion with healthcare provider"@en ;
     rdfs:domain diabetes:GlucosePattern ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Hypo/Hyper Events
@@ -502,51 +577,60 @@ diabetes:HypoglycemicEvent a owl:Class ;
     rdfs:label "Hypoglycemic Event"@en ;
     rdfs:comment "Episode of low blood glucose (<70 mg/dL)"@en ;
     rdfs:subClassOf prov:Entity ;
-    owl:sameAs sct:302866003 .
+    owl:sameAs sct:302866003 ;
+    vs:term_status "unstable" .
 
 diabetes:HyperglycemicEvent a owl:Class ;
     rdfs:label "Hyperglycemic Event"@en ;
     rdfs:comment "Episode of high blood glucose (>250 mg/dL)"@en ;
     rdfs:subClassOf prov:Entity ;
-    owl:sameAs sct:80394007 .
+    owl:sameAs sct:80394007 ;
+    vs:term_status "unstable" .
 
 diabetes:eventStart a owl:DatatypeProperty ;
     rdfs:label "Event Start"@en ;
     rdfs:comment "When glucose crossed threshold"@en ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 diabetes:eventEnd a owl:DatatypeProperty ;
     rdfs:label "Event End"@en ;
     rdfs:comment "When glucose returned to range"@en ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 diabetes:eventDurationMinutes a owl:DatatypeProperty ;
     rdfs:label "Event Duration (minutes)"@en ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 diabetes:nadir a owl:DatatypeProperty ;
     rdfs:label "Nadir"@en ;
     rdfs:comment "Lowest glucose value during hypoglycemic event"@en ;
     rdfs:domain diabetes:HypoglycemicEvent ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:peak a owl:DatatypeProperty ;
     rdfs:label "Peak"@en ;
     rdfs:comment "Highest glucose value during hyperglycemic event"@en ;
     rdfs:domain diabetes:HyperglycemicEvent ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:requiresAssistance a owl:DatatypeProperty ;
     rdfs:label "Requires Assistance"@en ;
     rdfs:comment "Whether third-party assistance was needed (Level 3 severe hypo)"@en ;
     rdfs:domain diabetes:HypoglycemicEvent ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+    vs:term_status "unstable" .
 
 diabetes:treatmentCarbs a owl:DatatypeProperty ;
     rdfs:label "Treatment Carbs"@en ;
     rdfs:comment "Carbohydrates consumed to treat hypoglycemia"@en ;
     rdfs:domain diabetes:HypoglycemicEvent ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Lab Results
@@ -556,32 +640,37 @@ diabetes:LabResult a owl:Class ;
     rdfs:label "Lab Result"@en ;
     rdfs:comment "Clinical laboratory test result"@en ;
     rdfs:subClassOf fhir:Observation ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:HbA1cResult a owl:Class ;
     rdfs:label "HbA1c Result"@en ;
     rdfs:comment "Hemoglobin A1c test result (3-month glucose average)"@en ;
-    rdfs:subClassOf diabetes:LabResult .
+    rdfs:subClassOf diabetes:LabResult ;
+    vs:term_status "unstable" .
 
 diabetes:hba1cValue a owl:DatatypeProperty ;
     rdfs:label "HbA1c Value (%)"@en ;
     rdfs:comment "HbA1c in percentage (NGSP/DCCT standard)"@en ;
     rdfs:domain diabetes:HbA1cResult ;
     rdfs:range xsd:double ;
-    owl:equivalentProperty loinc:4548-4 .
+    owl:equivalentProperty loinc:4548-4 ;
+    vs:term_status "unstable" .
 
 diabetes:hba1cMmolMol a owl:DatatypeProperty ;
     rdfs:label "HbA1c (mmol/mol)"@en ;
     rdfs:comment "HbA1c in IFCC units"@en ;
     rdfs:domain diabetes:HbA1cResult ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:fastingGlucose a owl:DatatypeProperty ;
     rdfs:label "Fasting Glucose"@en ;
     rdfs:comment "Fasting plasma glucose in mg/dL"@en ;
     rdfs:domain diabetes:LabResult ;
     rdfs:range xsd:double ;
-    owl:equivalentProperty loinc:1558-6 .
+    owl:equivalentProperty loinc:1558-6 ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Diabetes Profile
@@ -590,80 +679,93 @@ diabetes:fastingGlucose a owl:DatatypeProperty ;
 diabetes:DiabetesProfile a owl:Class ;
     rdfs:label "Diabetes Profile"@en ;
     rdfs:comment "User's diabetes-specific health profile and treatment settings"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:diabetesType a owl:ObjectProperty ;
     rdfs:label "Diabetes Type"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range diabetes:DiabetesType .
+    rdfs:range diabetes:DiabetesType ;
+    vs:term_status "unstable" .
 
 diabetes:diagnosisDate a owl:DatatypeProperty ;
     rdfs:label "Diagnosis Date"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:date .
+    rdfs:range xsd:date ;
+    vs:term_status "unstable" .
 
 diabetes:diagnosisAge a owl:DatatypeProperty ;
     rdfs:label "Diagnosis Age"@en ;
     rdfs:comment "Age at diagnosis in years"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 # Target ranges (personalizable per user/provider)
 diabetes:targetRangeLow a owl:DatatypeProperty ;
     rdfs:label "Target Range Low"@en ;
     rdfs:comment "Lower bound of target range in mg/dL (default 70)"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:targetRangeHigh a owl:DatatypeProperty ;
     rdfs:label "Target Range High"@en ;
     rdfs:comment "Upper bound of target range in mg/dL (default 180)"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:hypoglycemiaThreshold a owl:DatatypeProperty ;
     rdfs:label "Hypoglycemia Threshold"@en ;
     rdfs:comment "Alert threshold for low glucose in mg/dL (default 70)"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:hyperglycemiaThreshold a owl:DatatypeProperty ;
     rdfs:label "Hyperglycemia Threshold"@en ;
     rdfs:comment "Alert threshold for high glucose in mg/dL (default 250)"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # Insulin settings
 diabetes:carbRatio a owl:DatatypeProperty ;
     rdfs:label "Carb Ratio"@en ;
     rdfs:comment "Grams of carbs covered by 1 unit of insulin (I:C ratio)"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:correctionFactor a owl:DatatypeProperty ;
     rdfs:label "Correction Factor"@en ;
     rdfs:comment "Expected glucose drop per unit of insulin (ISF) in mg/dL"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:insulinOnBoardDuration a owl:DatatypeProperty ;
     rdfs:label "Insulin on Board Duration"@en ;
     rdfs:comment "Active insulin time in hours (typically 3-5)"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # Device information
 diabetes:activeCGM a owl:DatatypeProperty ;
     rdfs:label "Active CGM"@en ;
     rdfs:comment "Currently used CGM system"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:activeInsulinPump a owl:DatatypeProperty ;
     rdfs:label "Active Insulin Pump"@en ;
     rdfs:comment "Currently used insulin pump"@en ;
     rdfs:domain diabetes:DiabetesProfile ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Activity Correlation
@@ -672,41 +774,48 @@ diabetes:activeInsulinPump a owl:DatatypeProperty ;
 diabetes:ActivityCorrelation a owl:Class ;
     rdfs:label "Activity Correlation"@en ;
     rdfs:comment "Correlation between physical activity and glucose response"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:activityType a owl:DatatypeProperty ;
     rdfs:label "Activity Type"@en ;
     rdfs:comment "Type of exercise (walking, running, cycling, strength, etc.)"@en ;
     rdfs:domain diabetes:ActivityCorrelation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:activityDurationMinutes a owl:DatatypeProperty ;
     rdfs:label "Activity Duration"@en ;
     rdfs:comment "Duration of activity in minutes"@en ;
     rdfs:domain diabetes:ActivityCorrelation ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 diabetes:activityIntensity a owl:DatatypeProperty ;
     rdfs:label "Activity Intensity"@en ;
     rdfs:comment "Intensity level: low, moderate, high, vigorous"@en ;
     rdfs:domain diabetes:ActivityCorrelation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:preActivityGlucose a owl:DatatypeProperty ;
     rdfs:label "Pre-Activity Glucose"@en ;
     rdfs:domain diabetes:ActivityCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:postActivityGlucose a owl:DatatypeProperty ;
     rdfs:label "Post-Activity Glucose"@en ;
     rdfs:domain diabetes:ActivityCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:glucoseChangeRate a owl:DatatypeProperty ;
     rdfs:label "Glucose Change Rate"@en ;
     rdfs:comment "Average glucose change per minute during activity"@en ;
     rdfs:domain diabetes:ActivityCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Sleep Correlation
@@ -715,36 +824,42 @@ diabetes:glucoseChangeRate a owl:DatatypeProperty ;
 diabetes:SleepCorrelation a owl:Class ;
     rdfs:label "Sleep Correlation"@en ;
     rdfs:comment "Correlation between sleep and glucose patterns"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:sleepDurationHours a owl:DatatypeProperty ;
     rdfs:label "Sleep Duration"@en ;
     rdfs:comment "Total sleep time in hours"@en ;
     rdfs:domain diabetes:SleepCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:sleepQualityScore a owl:DatatypeProperty ;
     rdfs:label "Sleep Quality Score"@en ;
     rdfs:comment "Sleep quality from wearable (0-100)"@en ;
     rdfs:domain diabetes:SleepCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:overnightMeanGlucose a owl:DatatypeProperty ;
     rdfs:label "Overnight Mean Glucose"@en ;
     rdfs:domain diabetes:SleepCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:overnightGlucoseSD a owl:DatatypeProperty ;
     rdfs:label "Overnight Glucose SD"@en ;
     rdfs:comment "Glucose variability during sleep"@en ;
     rdfs:domain diabetes:SleepCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 diabetes:wakingGlucose a owl:DatatypeProperty ;
     rdfs:label "Waking Glucose"@en ;
     rdfs:comment "First glucose reading upon waking"@en ;
     rdfs:domain diabetes:SleepCorrelation ;
-    rdfs:range xsd:double .
+    rdfs:range xsd:double ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Device Data Sources
@@ -753,33 +868,39 @@ diabetes:wakingGlucose a owl:DatatypeProperty ;
 diabetes:DeviceDataSource a owl:Class ;
     rdfs:label "Device Data Source"@en ;
     rdfs:comment "Registered device or app providing diabetes-related data"@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 diabetes:deviceManufacturer a owl:DatatypeProperty ;
     rdfs:label "Device Manufacturer"@en ;
     rdfs:domain diabetes:DeviceDataSource ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:deviceModel a owl:DatatypeProperty ;
     rdfs:label "Device Model"@en ;
     rdfs:domain diabetes:DeviceDataSource ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:deviceSerialNumber a owl:DatatypeProperty ;
     rdfs:label "Device Serial Number"@en ;
     rdfs:domain diabetes:DeviceDataSource ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:firmwareVersion a owl:DatatypeProperty ;
     rdfs:label "Firmware Version"@en ;
     rdfs:domain diabetes:DeviceDataSource ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 diabetes:lastSyncTimestamp a owl:DatatypeProperty ;
     rdfs:label "Last Sync"@en ;
     rdfs:comment "When data was last synced from this device"@en ;
     rdfs:domain diabetes:DeviceDataSource ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Healthcare Standards Alignment Reference

--- a/ontologies/evidence/v1-draft/evidence.ttl
+++ b/ontologies/evidence/v1-draft/evidence.ttl
@@ -33,6 +33,18 @@
 @prefix dct:  <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
+@prefix vs:       <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+# ============================================================================
+# Changelog
+# ============================================================================
+# v1.0-draft.0.3 (2026-08-20) — Per-term maturity. Every term now carries
+#   vs:term_status (W3C SemWeb Vocabulary Status, originating in FOAF):
+#   "unstable" for draft terms, "archaic" for terms already marked
+#   owl:deprecated. The convention is per-TERM by design, so a vocabulary
+#   can promote individual terms in place without a namespace change;
+#   Cascade previously stated maturity once per vocabulary, in prose no
+#   machine could read. No term definition changed.
+
 # ============================================================================
 # Ontology Metadata
 # ============================================================================
@@ -42,8 +54,8 @@
     dct:description "Layer 2 cross-cutting vocabulary for grounding assertions in cited evidence with explicit verdicts."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-06-16"^^xsd:date ;
-    dct:modified "2026-07-01"^^xsd:date ;
-    owl:versionInfo "1.0-draft.0.2" ;
+    dct:modified "2026-08-20"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.3" ;
     rdfs:comment "Generalizes the assertion -> evidence -> verdict pattern needed by Cascade Workbench (checking claims pulled from AI conversations against a patient's records and literature), the Cascade Appeal system (citing clinical evidence against policy criteria, cf. coverage:deniedClinicalContext), and PGx/genomics decision support. Reuses core provenance primitives (cascade:extractionModel, cascade:extractionConfidence, cascade:requiresUserReview, prov:wasDerivedFrom) rather than redefining them. Uses 'Assertion' (not 'Claim') to avoid collision with coverage:ClaimRecord. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/evidence/v1-draft/> .
 
@@ -55,62 +67,73 @@ evidence:Assertion a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Assertion"@en ;
     rdfs:comment "A discrete, checkable statement extracted from a source (e.g. an AI conversation) or entered by the user, evaluated against evidence in the Pod and/or literature. Carries exactly one verdict and zero-or-more evidence links. The extraction of an Assertion from its source SHOULD be recorded with a cascade:AIExtractionActivity; an assertion surfaced by a general-purpose AI assistant SHOULD carry cascade:dataProvenance cascade:AIAsserted."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.1" .
+    owl:versionInfo "Added in evidence v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 evidence:EvidenceLink a owl:Class ;
     rdfs:label "Evidence Link"@en ;
     rdfs:comment "A reified link from an Assertion to one piece of evidence (a Pod record or an external Citation), carrying a stance (supports / contradicts / contextual). Modeled as a node so a single Assertion can carry multiple, differently-directed pieces of evidence. Pattern mirrors cascade:ConflictDetail."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.1" .
+    owl:versionInfo "Added in evidence v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 evidence:Citation a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Citation"@en ;
     rdfs:comment "An external bibliographic source (e.g. a research paper) used as evidence, identified by DOI and/or PMID. When retrieved into the Pod it is a first-class resource (recommended path literature/) so an evidence chip can resolve to it exactly as it resolves to a clinical record."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.1" .
+    owl:versionInfo "Added in evidence v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 evidence:GroundingActivity a owl:Class ;
     rdfs:subClassOf prov:Activity ;
     rdfs:label "Grounding Activity"@en ;
     rdfs:comment "A PROV-O Activity representing the model pass that graded an Assertion against evidence and produced its verdict. Distinct from cascade:AIExtractionActivity (which extracts structured records from documents); grounding grades free-text assertions. Reuses cascade:extractionModel to record the model."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.1" .
+    owl:versionInfo "Added in evidence v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 evidence:VerdictValue a owl:Class ;
     owl:deprecated true ;
     rdfs:label "Verdict Value (deprecated)"@en ;
     rdfs:comment "DEPRECATED in v1-draft.0.2: the flat verdict enumeration is superseded by the facet model (evidence:direction / evidence:basis / evidence:strength / evidence:settled / evidence:reason). Retained one release so draft-period data carrying evidence:verdict still validates; clients derive the flat value from the facets in code and MUST NOT serialize it going forward. Scheduled for removal at v1.0 graduation."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.1; deprecated in v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.1; deprecated in v1-draft.0.2" ;
+    vs:term_status "archaic" .
 
 evidence:StanceValue a owl:Class ;
     rdfs:label "Stance Value"@en ;
     rdfs:comment "Closed enumeration of the direction of an EvidenceLink. Instances are the named individuals below."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.1" .
+    owl:versionInfo "Added in evidence v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 # ── Facet enumeration classes (verdict taxonomy v2, grounding plan §4.1) ─────
 
 evidence:DirectionValue a owl:Class ;
     rdfs:label "Direction Value"@en ;
     rdfs:comment "Closed enumeration of what the evidence, in aggregate, says about the Assertion: Supports | Contradicts | Mixed | None. The per-link analogue is StanceValue; evidence:Supports and evidence:Contradicts are shared individuals of both."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:BasisValue a owl:Class ;
     rdfs:label "Basis Value"@en ;
     rdfs:comment "Closed enumeration of where the evidence is: Record | Literature | RecordAndLiterature | None. New bases (guideline, clinician annotation) slot in here without breaking any flat enum."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:StrengthValue a owl:Class ;
     rdfs:label "Strength Value"@en ;
     rdfs:comment "Closed enumeration of the quantity/quality of the evidence: Strong | Moderate | Weak. On basis Record, strength is a pure deterministic function of the match (guardrail G-2), never model-emitted."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:SettledValue a owl:Class ;
     rdfs:label "Settled Value"@en ;
     rdfs:comment "Closed enumeration of whether the Assertion is resolved: Settled | NeedsEvidence."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:NeedsEvidenceReasonValue a owl:Class ;
     rdfs:label "Needs-Evidence Reason Value"@en ;
     rdfs:comment "Closed enumeration of why an Assertion still needs evidence, when it does: NoRecord | NeedsLiterature | NotCheckableByNature."@en ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Named Individuals (enumerations)
@@ -119,54 +142,73 @@ evidence:NeedsEvidenceReasonValue a owl:Class ;
 # Deprecated flat verdicts (v1-draft.0.2): retained one release for draft-period
 # data; derive from the facets in code, do not serialize. Removal at v1.0.
 evidence:Supported       a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Supported (deprecated)"@en ;
-    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Supports. The patient's records and/or literature substantiate the assertion."@en .
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Supports. The patient's records and/or literature substantiate the assertion."@en ;
+    vs:term_status "archaic" .
 evidence:Contradicted    a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Contradicted (deprecated)"@en ;
-    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Contradicts. The patient's records and/or literature directly conflict with the assertion."@en .
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:Settled + evidence:direction evidence:Contradicts. The patient's records and/or literature directly conflict with the assertion."@en ;
+    vs:term_status "archaic" .
 evidence:Unverifiable    a owl:NamedIndividual, evidence:VerdictValue ; owl:deprecated true ; rdfs:label "Unverifiable (deprecated)"@en ;
-    rdfs:comment "DEPRECATED: use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NoRecord. No evidence available in the current Pod to support or refute. NOT a judgment that the assertion is false."@en .
+    rdfs:comment "DEPRECATED: use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NoRecord. No evidence available in the current Pod to support or refute. NOT a judgment that the assertion is false."@en ;
+    vs:term_status "archaic" .
 
 evidence:Supports    a owl:NamedIndividual, evidence:StanceValue, evidence:DirectionValue ; rdfs:label "Supports"@en ;
-    rdfs:comment "As a StanceValue: this one link supports. As a DirectionValue (v1-draft.0.2): the evidence in aggregate supports."@en .
+    rdfs:comment "As a StanceValue: this one link supports. As a DirectionValue (v1-draft.0.2): the evidence in aggregate supports."@en ;
+    vs:term_status "unstable" .
 evidence:Contradicts a owl:NamedIndividual, evidence:StanceValue, evidence:DirectionValue ; rdfs:label "Contradicts"@en ;
-    rdfs:comment "As a StanceValue: this one link contradicts. As a DirectionValue (v1-draft.0.2): the evidence in aggregate contradicts."@en .
+    rdfs:comment "As a StanceValue: this one link contradicts. As a DirectionValue (v1-draft.0.2): the evidence in aggregate contradicts."@en ;
+    vs:term_status "unstable" .
 evidence:Contextual  a owl:NamedIndividual, evidence:StanceValue ; rdfs:label "Contextual"@en ;
-    rdfs:comment "Relevant background that neither supports nor refutes."@en .
+    rdfs:comment "Relevant background that neither supports nor refutes."@en ;
+    vs:term_status "unstable" .
 
 # ── Facet individuals (v1-draft.0.2) ─────────────────────────────────────────
 
 evidence:Mixed a owl:NamedIndividual, evidence:DirectionValue ; rdfs:label "Mixed"@en ;
-    rdfs:comment "The evidence points in both directions; see the individual links."@en .
+    rdfs:comment "The evidence points in both directions; see the individual links."@en ;
+    vs:term_status "unstable" .
 evidence:None a owl:NamedIndividual, evidence:DirectionValue, evidence:BasisValue ; rdfs:label "None"@en ;
-    rdfs:comment "As a DirectionValue: the evidence says nothing. As a BasisValue: there is no evidence base. Shared individual; the property it appears on disambiguates."@en .
+    rdfs:comment "As a DirectionValue: the evidence says nothing. As a BasisValue: there is no evidence base. Shared individual; the property it appears on disambiguates."@en ;
+    vs:term_status "unstable" .
 
 evidence:Record a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Record"@en ;
-    rdfs:comment "The evidence is the patient's own Pod records (deterministic path, G-2)."@en .
+    rdfs:comment "The evidence is the patient's own Pod records (deterministic path, G-2)."@en ;
+    vs:term_status "unstable" .
 evidence:Literature a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Literature"@en ;
-    rdfs:comment "The evidence is published research; it has not been checked against the patient's records."@en .
+    rdfs:comment "The evidence is published research; it has not been checked against the patient's records."@en ;
+    vs:term_status "unstable" .
 evidence:RecordAndLiterature a owl:NamedIndividual, evidence:BasisValue ; rdfs:label "Record and Literature"@en ;
-    rdfs:comment "Both the patient's records and published research contribute evidence."@en .
+    rdfs:comment "Both the patient's records and published research contribute evidence."@en ;
+    vs:term_status "unstable" .
 
 evidence:Strong   a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Strong"@en ;
-    rdfs:comment "On the record path: exact code + value/negation match."@en .
+    rdfs:comment "On the record path: exact code + value/negation match."@en ;
+    vs:term_status "unstable" .
 evidence:Moderate a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Moderate"@en ;
-    rdfs:comment "On the record path: code match with value absent or approximate."@en .
+    rdfs:comment "On the record path: code match with value absent or approximate."@en ;
+    vs:term_status "unstable" .
 evidence:Weak     a owl:NamedIndividual, evidence:StrengthValue ; rdfs:label "Weak"@en ;
-    rdfs:comment "On the record path: lexical / recall-fallback match only."@en .
+    rdfs:comment "On the record path: lexical / recall-fallback match only."@en ;
+    vs:term_status "unstable" .
 
 evidence:Settled       a owl:NamedIndividual, evidence:SettledValue ; rdfs:label "Settled"@en ;
-    rdfs:comment "The claim is resolved by the cited evidence."@en .
+    rdfs:comment "The claim is resolved by the cited evidence."@en ;
+    vs:term_status "unstable" .
 evidence:NeedsEvidence a owl:NamedIndividual, evidence:SettledValue ; rdfs:label "Needs Evidence"@en ;
-    rdfs:comment "The claim is not resolved; evidence:reason says why. A NeedsEvidence assertion carries direction None (a grounded direction here is facet-inconsistent and fails validation)."@en .
+    rdfs:comment "The claim is not resolved; evidence:reason says why. A NeedsEvidence assertion carries direction None (a grounded direction here is facet-inconsistent and fails validation)."@en ;
+    vs:term_status "unstable" .
 
 evidence:NoRecord a owl:NamedIndividual, evidence:NeedsEvidenceReasonValue ; rdfs:label "No Record"@en ;
-    rdfs:comment "Nothing in the patient's records speaks to this. That does not make it wrong."@en .
+    rdfs:comment "Nothing in the patient's records speaks to this. That does not make it wrong."@en ;
+    vs:term_status "unstable" .
 evidence:NotCheckableByNature a owl:NamedIndividual, evidence:NeedsEvidenceReasonValue ; rdfs:label "Not Checkable By Nature"@en ;
-    rdfs:comment "Subjective, personal, or otherwise unverifiable by its nature (instruction, opinion, tautology, meta)."@en .
+    rdfs:comment "Subjective, personal, or otherwise unverifiable by its nature (instruction, opinion, tautology, meta)."@en ;
+    vs:term_status "unstable" .
 # evidence:NeedsLiterature doubles as a NeedsEvidenceReasonValue (below) and the
 # deprecated VerdictValue of the same local name; the code mirror uses the same
 # string for both, so one shared individual is exact.
 evidence:NeedsLiterature a owl:NamedIndividual, evidence:VerdictValue, evidence:NeedsEvidenceReasonValue ; rdfs:label "Needs Literature"@en ;
-    rdfs:comment "As a NeedsEvidenceReasonValue (v1-draft.0.2): the patient's records cannot settle this; it needs published evidence. As a VerdictValue it is DEPRECATED (use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NeedsLiterature)."@en .
+    rdfs:comment "As a NeedsEvidenceReasonValue (v1-draft.0.2): the patient's records cannot settle this; it needs published evidence. As a VerdictValue it is DEPRECATED (use evidence:settled evidence:NeedsEvidence + evidence:reason evidence:NeedsLiterature)."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Properties — Assertion
@@ -175,13 +217,15 @@ evidence:NeedsLiterature a owl:NamedIndividual, evidence:VerdictValue, evidence:
 evidence:assertionText a owl:DatatypeProperty ;
     rdfs:label "assertion text"@en ;
     rdfs:comment "The normalized, atomic statement being evaluated."@en ;
-    rdfs:domain evidence:Assertion ; rdfs:range xsd:string .
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 evidence:verdict a owl:ObjectProperty ;
     owl:deprecated true ;
     rdfs:label "verdict (deprecated)"@en ;
     rdfs:comment "DEPRECATED in v1-draft.0.2: superseded by the facet properties (direction / basis / strength / settled / reason / confidence), which are the canonical serialized form. Retained one release so draft-period data validates; derive the flat value from the facets in code, do not serialize it. Removal at v1.0 graduation."@en ;
-    rdfs:domain evidence:Assertion ; rdfs:range evidence:VerdictValue .
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:VerdictValue ;
+    vs:term_status "archaic" .
 
 # ── Facet properties (verdict taxonomy v2, v1-draft.0.2) ─────────────────────
 # The canonical grounding outcome. Grounding invariant (SHACL Core, see
@@ -193,61 +237,72 @@ evidence:direction a owl:ObjectProperty ;
     rdfs:label "direction"@en ;
     rdfs:comment "What the evidence, in aggregate, says about the assertion."@en ;
     rdfs:domain evidence:Assertion ; rdfs:range evidence:DirectionValue ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:basis a owl:ObjectProperty ;
     rdfs:label "basis"@en ;
     rdfs:comment "Where the evidence is. Tells the UI which regime produced the result: Record is the deterministic path (G-2), Literature is model+search."@en ;
     rdfs:domain evidence:Assertion ; rdfs:range evidence:BasisValue ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:strength a owl:ObjectProperty ;
     rdfs:label "strength"@en ;
     rdfs:comment "Quantity/quality of the evidence. On basis Record this is a pure deterministic function of the match (G-2), never model-emitted."@en ;
     rdfs:domain evidence:Assertion ; rdfs:range evidence:StrengthValue ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:settled a owl:ObjectProperty ;
     rdfs:label "settled"@en ;
     rdfs:comment "Whether the assertion is resolved by the cited evidence."@en ;
     rdfs:domain evidence:Assertion ; rdfs:range evidence:SettledValue ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:reason a owl:ObjectProperty ;
     rdfs:label "reason"@en ;
     rdfs:comment "Why the assertion still needs evidence, when settled is NeedsEvidence."@en ;
     rdfs:domain evidence:Assertion ; rdfs:range evidence:NeedsEvidenceReasonValue ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:confidence a owl:DatatypeProperty ;
     rdfs:label "confidence"@en ;
     rdfs:comment "Confidence in the grounding result, [0.0, 1.0]. On basis Record this is a fixed function of match quality, never a model probability (G-2); on the literature path it may reflect model certainty. Distinct from evidence:groundingConfidence, which is the GroundingActivity's raw model confidence."@en ;
     rdfs:domain evidence:Assertion ; rdfs:range xsd:decimal ;
-    owl:versionInfo "Added in evidence v1-draft.0.2" .
+    owl:versionInfo "Added in evidence v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 evidence:rationale a owl:DatatypeProperty ;
     rdfs:label "rationale"@en ;
     rdfs:comment "One-line plain-language explanation of the verdict."@en ;
-    rdfs:domain evidence:Assertion ; rdfs:range xsd:string .
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 evidence:disconfirming a owl:DatatypeProperty ;
     rdfs:label "disconfirming consideration"@en ;
     rdfs:comment "A 'what would argue against this' consideration. Multiple permitted. Required by product design for any material assertion (anti-confirmation-bias)."@en ;
-    rdfs:domain evidence:Assertion ; rdfs:range xsd:string .
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 evidence:hasEvidenceLink a owl:ObjectProperty ;
     rdfs:label "has evidence link"@en ;
-    rdfs:domain evidence:Assertion ; rdfs:range evidence:EvidenceLink .
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:EvidenceLink ;
+    vs:term_status "unstable" .
 
 evidence:groundedBy a owl:ObjectProperty ;
     rdfs:subPropertyOf prov:wasGeneratedBy ;
     rdfs:label "grounded by"@en ;
     rdfs:comment "Links an Assertion to the GroundingActivity that produced its verdict."@en ;
-    rdfs:domain evidence:Assertion ; rdfs:range evidence:GroundingActivity .
+    rdfs:domain evidence:Assertion ; rdfs:range evidence:GroundingActivity ;
+    vs:term_status "unstable" .
 
 evidence:assertedAt a owl:DatatypeProperty ;
     rdfs:label "asserted at"@en ;
-    rdfs:domain evidence:Assertion ; rdfs:range xsd:dateTime .
+    rdfs:domain evidence:Assertion ; rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 # Reuse (NOT redefined here): cascade:extractionModel, cascade:extractionConfidence,
 # and cascade:requiresUserReview carry the extraction provenance of an Assertion.
@@ -258,41 +313,51 @@ evidence:assertedAt a owl:DatatypeProperty ;
 
 evidence:evidenceStance a owl:ObjectProperty ;
     rdfs:label "evidence stance"@en ;
-    rdfs:domain evidence:EvidenceLink ; rdfs:range evidence:StanceValue .
+    rdfs:domain evidence:EvidenceLink ; rdfs:range evidence:StanceValue ;
+    vs:term_status "unstable" .
 
 evidence:citesRecord a owl:ObjectProperty ;
     rdfs:subPropertyOf prov:wasDerivedFrom ;
     rdfs:label "cites record"@en ;
     rdfs:comment "Points to a Pod record (clinical:, health:, pots:, genomics: ...) used as evidence. Range intentionally open (rdfs:Resource) for cross-namespace linking, mirroring coverage:deniedClinicalContext."@en ;
-    rdfs:domain evidence:EvidenceLink ; rdfs:range rdfs:Resource .
+    rdfs:domain evidence:EvidenceLink ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 
 evidence:citesSource a owl:ObjectProperty ;
     rdfs:label "cites source"@en ;
     rdfs:comment "Points to an external Citation (research paper) used as evidence."@en ;
-    rdfs:domain evidence:EvidenceLink ; rdfs:range evidence:Citation .
+    rdfs:domain evidence:EvidenceLink ; rdfs:range evidence:Citation ;
+    vs:term_status "unstable" .
 
 evidence:evidenceWeight a owl:DatatypeProperty ;
     rdfs:label "evidence weight"@en ;
     rdfs:comment "Optional 0.0-1.0 strength of this evidence link toward the verdict."@en ;
-    rdfs:domain evidence:EvidenceLink ; rdfs:range xsd:decimal .
+    rdfs:domain evidence:EvidenceLink ; rdfs:range xsd:decimal ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Properties — Citation
 # ============================================================================
 
 evidence:doi a owl:DatatypeProperty ; rdfs:label "DOI"@en ;
-    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 evidence:pmid a owl:DatatypeProperty ; rdfs:label "PMID"@en ;
-    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 evidence:citationTitle a owl:DatatypeProperty ; rdfs:label "title"@en ;
-    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 evidence:citationYear a owl:DatatypeProperty ; rdfs:label "year"@en ;
-    rdfs:domain evidence:Citation ; rdfs:range xsd:gYear .
+    rdfs:domain evidence:Citation ; rdfs:range xsd:gYear ;
+    vs:term_status "unstable" .
 evidence:citationSourceName a owl:DatatypeProperty ; rdfs:label "source name"@en ;
     rdfs:comment "Retrieval source, e.g. 'PubMed', 'Europe PMC'."@en ;
-    rdfs:domain evidence:Citation ; rdfs:range xsd:string .
+    rdfs:domain evidence:Citation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 evidence:retrievedAt a owl:DatatypeProperty ; rdfs:label "retrieved at"@en ;
-    rdfs:domain evidence:Citation ; rdfs:range xsd:dateTime .
+    rdfs:domain evidence:Citation ; rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Properties — GroundingActivity
@@ -301,5 +366,6 @@ evidence:retrievedAt a owl:DatatypeProperty ; rdfs:label "retrieved at"@en ;
 evidence:groundingConfidence a owl:DatatypeProperty ;
     rdfs:label "grounding confidence"@en ;
     rdfs:comment "Model confidence in the produced verdict, [0.0, 1.0]."@en ;
-    rdfs:domain evidence:GroundingActivity ; rdfs:range xsd:decimal .
+    rdfs:domain evidence:GroundingActivity ; rdfs:range xsd:decimal ;
+    vs:term_status "unstable" .
 # Reuses cascade:extractionModel to record which model performed the grounding.

--- a/ontologies/genomics/v1-draft/genomics.ttl
+++ b/ontologies/genomics/v1-draft/genomics.ttl
@@ -18,6 +18,18 @@
 @prefix orpha:    <http://www.orpha.net/ORDO/Orphanet_> .
 @prefix clinvar:  <https://www.ncbi.nlm.nih.gov/clinvar/variation/> .
 
+@prefix vs:       <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+# ============================================================================
+# Changelog
+# ============================================================================
+# v1.0-draft.0.5 (2026-08-20) — Per-term maturity. Every term now carries
+#   vs:term_status (W3C SemWeb Vocabulary Status, originating in FOAF):
+#   "unstable" for draft terms, "archaic" for terms already marked
+#   owl:deprecated. The convention is per-TERM by design, so a vocabulary
+#   can promote individual terms in place without a namespace change;
+#   Cascade previously stated maturity once per vocabulary, in prose no
+#   machine could read. No term definition changed.
+
 # ============================================================================
 # Ontology Metadata
 # ============================================================================
@@ -29,8 +41,8 @@
     dct:description "Layer 2 vocabulary for sequence variants, variant interpretations, haplotypes/diplotypes, copy number variants, sequencing-run metadata, raw-file pointers, pedigrees, and genetic test reports/orders. Bridges Layer 1 standards (HGVS, ClinVar, VRS, HGNC, Sequence Ontology, HPO, MONDO/OMIM/ORDO, ACMG/AMP via LOINC answer codes, ClinGen review-status taxonomy) to Layer 3 patient-facing genetic counseling summaries in checkup:."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-05-05"^^xsd:date ;
-    dct:modified "2026-06-16"^^xsd:date ;
-    owl:versionInfo "1.0-draft" ;
+    dct:modified "2026-08-20"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.5" ;
     rdfs:comment """DRAFT — pre-stable v1 ontology. Property names, ranges, and structure may change before v1.0 stable release.
         Three-layer ontology for genomics:
           Layer 1 (Established): HGVS nomenclature, VRS, ClinVar, HGNC, Sequence Ontology,
@@ -44,7 +56,7 @@
           Layer 3 (checkup:):    GeneticCounselingSummary, VariantNarrative — patient-facing
                                  aggregations and regeneratable narrative (authored separately
                                  in the checkup vocabulary)."""@en ;
-    rdfs:seeAlso <https://cascadeprotocol.org/docs/genomics/v1/> .
+    rdfs:seeAlso <https://cascadeprotocol.org/docs/genomics/v1-draft/> .
 
 # Changelog:
 # v1.0-draft.0.2 (2026-05-05): Phase 1 evolution candidates landed after the FHIR
@@ -89,29 +101,34 @@ genomics:Variant a owl:Class ;
         a owl:Restriction ;
         owl:onProperty genomics:geneSymbol ;
         owl:cardinality 1
-    ] .
+    ] ;
+    vs:term_status "unstable" .
 
 genomics:VariantInterpretation a owl:Class ;
     rdfs:label "Variant Interpretation"@en ;
     rdfs:comment "A clinical-significance assertion linking a Variant to a single condition (per D-Q5 — multi-condition cases produce multiple Interpretation instances), with ACMG/AMP classification, supporting criteria, and an interpreting laboratory or expert panel. Reclassifications produce new Interpretation instances linked to the prior via prov:wasRevisionOf — interpretations are versioned, not edited. SHACL enforces genomics:condition and genomics:variantInterpreted both at cardinality 1..1 (see genomics.shapes.ttl, TASK-0.2)."@en ;
     rdfs:subClassOf fhir:Observation ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 genomics:GeneticTest a owl:Class ;
     rdfs:label "Genetic Test Report"@en ;
     rdfs:comment "Result envelope from a clinical genetic test (panel, exome, single-gene). Aggregates Variant observations, gene panel scope, methodology, and ordering provider. Maps to FHIR DiagnosticReport. For test orders that have not yet resulted, see genomics:GeneticTestOrder."@en ;
     rdfs:subClassOf fhir:DiagnosticReport ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 genomics:GeneticTestOrder a owl:Class ;
     rdfs:label "Genetic Test Order"@en ;
     rdfs:comment "An order/request for a genetic test, distinct from the resulting GeneticTest. Maps to FHIR ServiceRequest. Counseling workflows track 'ordered but not yet resulted' state via this class. Once the order is fulfilled, link the resulting GeneticTest via genomics:resultedIn."@en ;
     rdfs:subClassOf fhir:ServiceRequest ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 genomics:Gene a owl:Class ;
     rdfs:label "Gene"@en ;
-    rdfs:comment "A gene reference, identified by HGNC approved symbol and ID. Used as the target of variant observations and gene-disease associations."@en .
+    rdfs:comment "A gene reference, identified by HGNC approved symbol and ID. Used as the target of variant observations and gene-disease associations."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Haplotype, Diplotype, Copy Number Variants
@@ -126,18 +143,21 @@ genomics:Haplotype a owl:Class ;
     rdfs:label "Haplotype"@en ;
     rdfs:comment "A multi-variant unit travelling together on one chromosome — the unit of clinical interpretation in pharmacogenomics (PharmVar star alleles like CYP2C19*2, CYP2D6*4) and HLA typing (HLA-DQB1*02:01). Cannot be expressed as a single Variant. Anchored on fhir:Observation per FHIR Genomics IG haplotype profile."@en ;
     rdfs:subClassOf fhir:Observation ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 genomics:Diplotype a owl:Class ;
     rdfs:label "Diplotype"@en ;
     rdfs:comment "A pair of haplotypes (e.g., '*1/*2'), required for any pharmacogenomics or HLA typing use case. Anchored on fhir:Observation per FHIR Genomics IG genotype profile."@en ;
     rdfs:subClassOf fhir:Observation ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 genomics:CopyNumberVariant a owl:Class ;
     rdfs:label "Copy Number Variant"@en ;
     rdfs:comment "A structural variant defined by deletion or duplication of a genomic interval, expressed as integer copy number plus interval coordinates rather than HGVS. Required for structural-variant cases (e.g., 13q14 deletion in retinoblastoma). subClassOf genomics:Variant — inherits stable-ID and zygosity properties where applicable."@en ;
-    rdfs:subClassOf genomics:Variant .
+    rdfs:subClassOf genomics:Variant ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Sequencing Run & Raw File Metadata (per D-DIRECTORY)
@@ -150,12 +170,14 @@ genomics:CopyNumberVariant a owl:Class ;
 genomics:SequencingRun a owl:Class ;
     rdfs:label "Sequencing Run"@en ;
     rdfs:comment "Metadata for a single sequencing run that produced one or more variants. Captures coverage depth, technology, variant-caller version, laboratory certification, and key dates (sample collection, sequencing, file generation). Used to populate the data-quality tier on derived Variants and to trace provenance back to lab process."@en ;
-    rdfs:subClassOf prov:Activity .
+    rdfs:subClassOf prov:Activity ;
+    vs:term_status "unstable" .
 
 genomics:RawFile a owl:Class ;
     rdfs:label "Raw Genomic File"@en ;
     rdfs:comment "Pointer-and-hash record for a raw genomic file (BAM, CRAM, FASTQ, gVCF, VCF, BCF). Cascade does NOT ingest the bytes — only the manifest. The bytes live wherever the user keeps them (lab cloud, local disk, NAS, htsget-served). genomics:fileLocation may be opaque (s3://, https://, file://, or a vendor-specific URI) and is not validated by Cascade."@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Variant Identity Properties — HGVS Nomenclature
@@ -168,21 +190,24 @@ genomics:hgvsCDot a owl:DatatypeProperty ;
     rdfs:comment "Variant described against a coding-sequence (transcript) reference, e.g. 'NM_000059.4:c.5946delT'. Includes transcript accession with version. This is the form most often cited in clinical reports."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:48004-6 .  # DNA change (c.HGVS)
+    genomics:loincCode loinc:48004-6 ;
+    vs:term_status "unstable" .  # DNA change (c.HGVS)
 
 genomics:hgvsPDot a owl:DatatypeProperty ;
     rdfs:label "HGVS Protein Description"@en ;
     rdfs:comment "Variant described at the protein level, e.g. 'NP_000050.3:p.Ser1982Argfs*22'. Use parentheses (p.(Ser1982Argfs*22)) when the protein consequence is predicted from the DNA change rather than directly observed."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:48005-3 .  # Amino acid change (p.HGVS)
+    genomics:loincCode loinc:48005-3 ;
+    vs:term_status "unstable" .  # Amino acid change (p.HGVS)
 
 genomics:hgvsGDot a owl:DatatypeProperty ;
     rdfs:label "HGVS Genomic Description"@en ;
     rdfs:comment "Variant described against a genomic reference, e.g. 'NC_000013.11:g.32340301del'. Required for cross-transcript joins and for variants outside coding regions."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:81290-9 .  # Genomic ref allele
+    genomics:loincCode loinc:81290-9 ;
+    vs:term_status "unstable" .  # Genomic ref allele
 
 # Added in v1-draft.0.2: VCF-style coordinate properties. FHIR Genomics IG
 # variants frequently carry the LOINC 69547-8 / 69551-0 / 81254-5 components
@@ -192,39 +217,45 @@ genomics:refAllele a owl:DatatypeProperty ;
     rdfs:comment "The reference base sequence at the variant position, as defined by the reference genome assembly. ATCG[N], typically 1–N bases. Per VCF REF / FHIR Genomics IG LOINC 69547-8."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:69547-8 .  # Genomic ref allele [ID]
+    genomics:loincCode loinc:69547-8 ;
+    vs:term_status "unstable" .  # Genomic ref allele [ID]
 
 genomics:altAllele a owl:DatatypeProperty ;
     rdfs:label "Alternate Allele"@en ;
     rdfs:comment "The variant allele sequence at the variant position. ATCG[N] for substitutions/insertions; '-' or empty for deletions; structured forms like '<DEL>'/'<DUP>' for symbolic alleles. Per VCF ALT / FHIR Genomics IG LOINC 69551-0."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:69551-0 .  # Genomic alt allele [ID]
+    genomics:loincCode loinc:69551-0 ;
+    vs:term_status "unstable" .  # Genomic alt allele [ID]
 
 genomics:genomicStartEnd a owl:DatatypeProperty ;
     rdfs:label "Genomic Start-End Coordinates"@en ;
     rdfs:comment "The 1-based inclusive start-end coordinates of the variant on the reference assembly, formatted as 'chrN:start-end' (e.g., 'chr17:43124027-43124028'). Pair with genomics:referenceGenome for full anchoring. Per FHIR Genomics IG LOINC 81254-5."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:81254-5 .  # Genomic allele start-end
+    genomics:loincCode loinc:81254-5 ;
+    vs:term_status "unstable" .  # Genomic allele start-end
 
 genomics:hgvsProteinObserved a owl:DatatypeProperty ;
     rdfs:label "Protein Consequence Directly Observed"@en ;
     rdfs:comment "True when the p.HGVS description was directly observed at the protein level (e.g. mass spec, functional assay). False or absent means the protein consequence was predicted from the DNA change. Conventionally encoded in HGVS by parentheses around the p. description."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+    vs:term_status "unstable" .
 
 genomics:transcriptRef a owl:DatatypeProperty ;
     rdfs:label "Reference Transcript"@en ;
     rdfs:comment "RefSeq transcript accession with version, e.g. 'NM_000059.4'. Stored separately from the HGVS string so that downstream tools can reason about transcript version drift, the most common source of variant ambiguity in clinical handoffs."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:genomeAssembly a owl:DatatypeProperty ;
     rdfs:label "Reference Genome Assembly"@en ;
     rdfs:comment "Reference genome build, e.g. 'GRCh38' or 'GRCh37'. Required when interpreting g.HGVS coordinates."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Variant Identity Properties — Stable Identifiers
@@ -237,37 +268,43 @@ genomics:clinvarVariationId a owl:DatatypeProperty ;
     rdfs:comment "ClinVar VCV accession identifying the variant (not the variant-condition pair). Example: 'VCV000051062' for BRCA2 c.5946delT."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:81252-9 .  # Discrete genetic variant
+    genomics:loincCode loinc:81252-9 ;
+    vs:term_status "unstable" .  # Discrete genetic variant
 
 genomics:clinvarRcvId a owl:DatatypeProperty ;
     rdfs:label "ClinVar RCV ID"@en ;
     rdfs:comment "ClinVar RCV accession identifying a variant-condition assertion. Multiple RCVs typically attach to one VCV. Lives on VariantInterpretation, not Variant."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:dbsnpRsId a owl:DatatypeProperty ;
     rdfs:label "dbSNP rsID"@en ;
     rdfs:comment "NCBI dbSNP reference SNP identifier, e.g. 'rs80359550'. Primary join key for consumer-array (23andMe / AncestryDNA / etc.) imports."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:caId a owl:DatatypeProperty ;
     rdfs:label "ClinGen Allele Registry CAid"@en ;
     rdfs:comment "ClinGen Allele Registry canonical allele identifier. Stable across HGVS reformulations and assembly changes — the recommended primary join key when available."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:vrsId a owl:DatatypeProperty ;
     rdfs:label "GA4GH VRS Identifier"@en ;
     rdfs:comment "Deterministic computable hash identifier per GA4GH Variation Representation Spec. Computed from the normalized sequence-location-state object; identical variants always hash to the same VRS ID regardless of how they were originally described."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:vrsObject a owl:DatatypeProperty ;
     rdfs:label "VRS Allele Object (JSON-LD)"@en ;
     rdfs:comment "Full VRS Allele JSON-LD payload as serialized string. Carries sequence reference, location interval, and state. Permits round-trip to other VRS-aware systems without re-parsing the HGVS."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Gene & Consequence Properties
@@ -278,38 +315,44 @@ genomics:geneSymbol a owl:DatatypeProperty ;
     rdfs:comment "HGNC approved gene symbol, e.g. 'BRCA2'. Always use the approved symbol, never an alias."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:string ;
-    genomics:loincCode loinc:48018-6 .  # Gene studied
+    genomics:loincCode loinc:48018-6 ;
+    vs:term_status "unstable" .  # Gene studied
 
 genomics:hgncId a owl:DatatypeProperty ;
     rdfs:label "HGNC ID"@en ;
     rdfs:comment "HGNC numeric identifier with prefix, e.g. 'HGNC:1101' for BRCA2. Stable across symbol changes."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:consequenceTerm a owl:ObjectProperty ;
     rdfs:label "Sequence Ontology Consequence"@en ;
     rdfs:comment "Sequence Ontology term URI describing the molecular consequence of the variant, e.g. so:0001589 (frameshift_variant), so:0001583 (missense_variant), so:0001587 (stop_gained)."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range owl:Class .
+    rdfs:range owl:Class ;
+    vs:term_status "unstable" .
 
 genomics:consequenceLabel a owl:DatatypeProperty ;
     rdfs:label "Consequence Label"@en ;
     rdfs:comment "Human-readable consequence label paired with the SO URI for legibility, e.g. 'frameshift_variant'."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:zygosity a owl:ObjectProperty ;
     rdfs:label "Zygosity"@en ;
     rdfs:comment "Zygosity of the observed variant. Named-individual values: genomics:Heterozygous, Homozygous, Hemizygous, CompoundHeterozygous, MosaicLow, MosaicHigh. For mosaic variants, also populate genomics:mosaicismFraction with the actual VAF."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range genomics:ZygosityValue ;
-    genomics:loincCode loinc:53034-5 .  # Allelic state
+    genomics:loincCode loinc:53034-5 ;
+    vs:term_status "unstable" .  # Allelic state
 
 genomics:mosaicismFraction a owl:DatatypeProperty ;
     rdfs:label "Mosaicism Fraction (VAF)"@en ;
     rdfs:comment "Variant allele fraction (0.0–1.0) for mosaic variants. Distinct from zygosity, which is categorical. The continuous VAF is the load-bearing number for clinical decisions in somatic mosaicism scenarios. NOTE (v1-draft.0.2): for the broader 'fraction of reads supporting alt allele' use genomics:variantAlleleFrequency; mosaicismFraction is reserved for the clinical conclusion that the variant is present in only a subset of cells."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range xsd:decimal .
+    rdfs:range xsd:decimal ;
+    vs:term_status "unstable" .
 
 # Added in v1-draft.0.2: VAF as a distinct property from mosaicismFraction.
 # VAF is the broader concept (any sequencing read fraction supporting the alt
@@ -321,7 +364,8 @@ genomics:variantAlleleFrequency a owl:DatatypeProperty ;
     rdfs:comment "Fraction of sequencing reads at the variant position that support the alternate allele. Range 0.0–1.0. Per FHIR Genomics IG LOINC 81258-6. Distinct from genomics:mosaicismFraction — VAF is a sequencing-evidence fraction; mosaicism is the clinical conclusion that the variant is present in only a subset of cells (which often, but not always, manifests as low VAF)."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range xsd:decimal ;
-    genomics:loincCode loinc:81258-6 .  # Sample variant allelic frequency [NFr]
+    genomics:loincCode loinc:81258-6 ;
+    vs:term_status "unstable" .  # Sample variant allelic frequency [NFr]
 
 # Added in v1-draft.0.2: variant origin (germline vs. somatic). LOINC 48002-0
 # is one of the most clinically important variant attributes. Critical for
@@ -331,19 +375,22 @@ genomics:somaticStatus a owl:ObjectProperty ;
     rdfs:comment "Whether the variant is germline (inherited / present in all cells) or somatic (acquired / tissue-specific). Critical for cancer interpretation and inheritance reasoning. Per FHIR Genomics IG LOINC 48002-0."@en ;
     rdfs:domain genomics:Variant ;
     rdfs:range genomics:SomaticStatus ;
-    genomics:loincCode loinc:48002-0 .  # Genomic source class
+    genomics:loincCode loinc:48002-0 ;
+    vs:term_status "unstable" .  # Genomic source class
 
 genomics:phase a owl:ObjectProperty ;
     rdfs:label "Allelic Phase"@en ;
     rdfs:comment "For compound heterozygous calls in the same gene: whether the two variants are in cis (same chromosome) or trans (opposite chromosomes). Values: genomics:Cis, Trans, PhaseUnknown. Critical for autosomal recessive inheritance interpretation."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range genomics:PhaseValue .
+    rdfs:range genomics:PhaseValue ;
+    vs:term_status "unstable" .
 
 genomics:phasedWith a owl:ObjectProperty ;
     rdfs:label "Phased With Variant"@en ;
     rdfs:comment "Links to the partner Variant when phase has been determined for a compound-heterozygous pair. Symmetric (each variant phasedWith the other)."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range genomics:Variant .
+    rdfs:range genomics:Variant ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Haplotype & Diplotype Properties
@@ -353,31 +400,36 @@ genomics:hasComponent a owl:ObjectProperty ;
     rdfs:label "Haplotype Component Variant"@en ;
     rdfs:comment "Links a Haplotype to one of its component Variants. A haplotype is composed of multiple variants that travel together on one chromosome."@en ;
     rdfs:domain genomics:Haplotype ;
-    rdfs:range genomics:Variant .
+    rdfs:range genomics:Variant ;
+    vs:term_status "unstable" .
 
 genomics:starAlleleSymbol a owl:DatatypeProperty ;
     rdfs:label "Star Allele Symbol"@en ;
     rdfs:comment "PharmVar/HLA-style nomenclature, e.g. 'CYP2C19*2', 'HLA-DQB1*02:01'. The clinically actionable identifier in pharmacogenomics and HLA typing."@en ;
     rdfs:domain genomics:Haplotype ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:diplotypeNotation a owl:DatatypeProperty ;
     rdfs:label "Diplotype Notation"@en ;
     rdfs:comment "Compact paired-haplotype notation, e.g. '*1/*2'. Computed from hapA + hapB; carried as a string for human readability and direct match against PGx guideline tables."@en ;
     rdfs:domain genomics:Diplotype ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:hapA a owl:ObjectProperty ;
     rdfs:label "Haplotype A"@en ;
     rdfs:comment "First haplotype of a diplotype pair. Order (A vs B) is arbitrary but must be stable within a record."@en ;
     rdfs:domain genomics:Diplotype ;
-    rdfs:range genomics:Haplotype .
+    rdfs:range genomics:Haplotype ;
+    vs:term_status "unstable" .
 
 genomics:hapB a owl:ObjectProperty ;
     rdfs:label "Haplotype B"@en ;
     rdfs:comment "Second haplotype of a diplotype pair."@en ;
     rdfs:domain genomics:Diplotype ;
-    rdfs:range genomics:Haplotype .
+    rdfs:range genomics:Haplotype ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Copy Number Variant Properties
@@ -387,25 +439,29 @@ genomics:copyNumber a owl:DatatypeProperty ;
     rdfs:label "Copy Number"@en ;
     rdfs:comment "Integer copy number observed for the genomic interval, e.g. 1 (heterozygous deletion), 0 (homozygous deletion), 3 (single duplication), 4+ (amplification). Distinct from zygosity."@en ;
     rdfs:domain genomics:CopyNumberVariant ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 genomics:cnvIntervalStart a owl:DatatypeProperty ;
     rdfs:label "CNV Interval Start"@en ;
     rdfs:comment "Start coordinate (1-based, inclusive) of the CNV interval on the reference indicated by cnvIntervalRef."@en ;
     rdfs:domain genomics:CopyNumberVariant ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 genomics:cnvIntervalEnd a owl:DatatypeProperty ;
     rdfs:label "CNV Interval End"@en ;
     rdfs:comment "End coordinate (1-based, inclusive) of the CNV interval."@en ;
     rdfs:domain genomics:CopyNumberVariant ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 genomics:cnvIntervalRef a owl:DatatypeProperty ;
     rdfs:label "CNV Interval Reference"@en ;
     rdfs:comment "Genomic reference for the interval coordinates, e.g. 'NC_000013.11' (chromosome 13 in GRCh38) or a chromosome name. Required for downstream analyses to locate the interval."@en ;
     rdfs:domain genomics:CopyNumberVariant ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Variant Interpretation Properties (ACMG/AMP)
@@ -415,68 +471,79 @@ genomics:variantInterpreted a owl:ObjectProperty ;
     rdfs:label "Variant Interpreted"@en ;
     rdfs:comment "The Variant being assessed by this VariantInterpretation. SHACL enforces cardinality 1..1 (per D-Q5)."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range genomics:Variant .
+    rdfs:range genomics:Variant ;
+    vs:term_status "unstable" .
 
 genomics:acmgClassification a owl:ObjectProperty ;
     rdfs:label "ACMG/AMP Classification"@en ;
     rdfs:comment "Five-tier ACMG/AMP classification. Named-individual values map 1:1 to LOINC answer codes: Pathogenic (LA6668-3), LikelyPathogenic (LA26332-9), VUS (LA26333-7), LikelyBenign (LA26334-5), Benign (LA6675-8)."@en ;
     rdfs:domain genomics:VariantInterpretation ;
     rdfs:range genomics:AcmgClass ;
-    genomics:loincCode loinc:53037-8 .  # Genetic variation clinical significance
+    genomics:loincCode loinc:53037-8 ;
+    vs:term_status "unstable" .  # Genetic variation clinical significance
 
 genomics:acmgCriteria a owl:DatatypeProperty ;
     rdfs:label "ACMG Evidence Criteria"@en ;
     rdfs:comment "Space-separated ACMG/AMP evidence criteria codes applied in this classification, e.g. 'PVS1 PM2 PP5'. Order is not significant."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:condition a owl:ObjectProperty ;
     rdfs:label "Associated Condition"@en ;
     rdfs:comment "Disease or condition associated with this interpretation. Range is a MONDO/OMIM/ORDO term URI. Per D-Q5, each VariantInterpretation has cardinality 1..1 on this property — multi-condition cases produce multiple interpretation instances."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range owl:Class .
+    rdfs:range owl:Class ;
+    vs:term_status "unstable" .
 
 genomics:mondoId a owl:DatatypeProperty ;
     rdfs:label "MONDO Disease ID"@en ;
     rdfs:comment "MONDO disease ontology ID, e.g. 'MONDO:0007254' for Hereditary breast carcinoma."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:omimId a owl:DatatypeProperty ;
     rdfs:label "OMIM Phenotype/Gene ID"@en ;
     rdfs:comment "OMIM identifier (six-digit) for a Mendelian phenotype or gene, e.g. '604370' for Breast-ovarian cancer, familial, susceptibility to, 2."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:orphaCode a owl:DatatypeProperty ;
     rdfs:label "Orphanet Code"@en ;
     rdfs:comment "Orphanet rare disease code, e.g. 'ORPHA:145' for Hereditary breast and ovarian cancer syndrome."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:inheritanceMode a owl:ObjectProperty ;
     rdfs:label "Mode of Inheritance"@en ;
     rdfs:comment "GenCC-aligned mode of inheritance for the gene-disease relationship. Named-individual values: AutosomalDominant, AutosomalRecessive, XLinkedDominant, XLinkedRecessive, Mitochondrial, YLinked, MultifactorialPolygenic, UnknownInheritance."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range genomics:InheritanceMode .
+    rdfs:range genomics:InheritanceMode ;
+    vs:term_status "unstable" .
 
 genomics:allelicRequirement a owl:ObjectProperty ;
     rdfs:label "Allelic Requirement"@en ;
     rdfs:comment "GenCC allelic requirement: monoallelic, biallelic, etc. Captures whether one or two copies of a pathogenic variant are required for the disease phenotype."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range genomics:AllelicRequirement .
+    rdfs:range genomics:AllelicRequirement ;
+    vs:term_status "unstable" .
 
 genomics:interpretedBy a owl:DatatypeProperty ;
     rdfs:label "Interpreting Laboratory or Expert Panel"@en ;
     rdfs:comment "Name of the lab, ClinGen Variant Curation Expert Panel (VCEP), or curator who issued this interpretation. Free-text for now; will be replaced with a fhir:Organization reference in v1.0."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:interpretedDate a owl:DatatypeProperty ;
     rdfs:label "Interpretation Date"@en ;
     rdfs:comment "Date this interpretation was issued. Reclassifications create new Interpretation instances; the date here is the date of THIS classification, not the original."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:date .
+    rdfs:range xsd:date ;
+    vs:term_status "unstable" .
 
 # Reclassifications — use prov:wasRevisionOf to chain interpretation versions.
 # Example: a VUS that becomes Likely Pathogenic links the new Interpretation
@@ -493,54 +560,63 @@ genomics:interpretedDate a owl:DatatypeProperty ;
 genomics:SubmitterAssertion a owl:Class ;
     rdfs:label "Submitter Assertion"@en ;
     rdfs:comment "A single submitter's assertion about a variant-condition pair, e.g. one ClinVar SCV record. Aggregated assertions roll up into a VariantInterpretation via genomics:aggregatedFrom. Individual submissions may disagree with the aggregate (most agree, but ENIGMA, Mayo, Ambry, etc. can each carry distinct opinions)."@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 genomics:aggregatedFrom a owl:ObjectProperty ;
     rdfs:label "Aggregated From"@en ;
     rdfs:comment "Links a VariantInterpretation to the SubmitterAssertions it aggregates. The aggregate classification is computed from these per-submitter records; preserving the constituents lets downstream tools recompute or audit the rollup."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range genomics:SubmitterAssertion .
+    rdfs:range genomics:SubmitterAssertion ;
+    vs:term_status "unstable" .
 
 genomics:assertedClassification a owl:ObjectProperty ;
     rdfs:label "Asserted ACMG Classification"@en ;
     rdfs:comment "The ACMG class assigned by this individual submitter. May differ from the aggregate classification on the parent VariantInterpretation."@en ;
     rdfs:domain genomics:SubmitterAssertion ;
-    rdfs:range genomics:AcmgClass .
+    rdfs:range genomics:AcmgClass ;
+    vs:term_status "unstable" .
 
 genomics:submitter a owl:DatatypeProperty ;
     rdfs:label "Submitter Name"@en ;
     rdfs:comment "Name of the submitting laboratory, consortium, or expert panel, e.g. 'ENIGMA', 'Ambry Genetics', 'Mayo Clinic'."@en ;
     rdfs:domain genomics:SubmitterAssertion ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:submitterOrgId a owl:DatatypeProperty ;
     rdfs:label "Submitter Organization ID"@en ;
     rdfs:comment "ClinVar OrgID (or equivalent submitter registry identifier) for the submitting organization."@en ;
     rdfs:domain genomics:SubmitterAssertion ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:submitterCategory a owl:ObjectProperty ;
     rdfs:label "Submitter Category"@en ;
     rdfs:comment "Class of submitter: laboratory, consortium, expert-panel, research-group, single-clinician, etc. Drives review-status weighting."@en ;
     rdfs:domain genomics:SubmitterAssertion ;
-    rdfs:range genomics:SubmitterCategory .
+    rdfs:range genomics:SubmitterCategory ;
+    vs:term_status "unstable" .
 
 genomics:scvAccession a owl:DatatypeProperty ;
     rdfs:label "SCV Accession"@en ;
     rdfs:comment "ClinVar SCV (Submission) accession identifying this individual submission, e.g. 'SCV000123456'."@en ;
     rdfs:domain genomics:SubmitterAssertion ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:contributesToAggregate a owl:DatatypeProperty ;
     rdfs:label "Contributes to Aggregate"@en ;
     rdfs:comment "True when this submission is included in the aggregate classification. Some submissions are excluded (withdrawn, superseded, flagged) but retained for audit."@en ;
     rdfs:domain genomics:SubmitterAssertion ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+    vs:term_status "unstable" .
 
 genomics:assertionEvidenceLevel a owl:ObjectProperty ;
     rdfs:label "Assertion Evidence Level"@en ;
     rdfs:comment "Strength-of-evidence label per the submitter's review process. Range is a vocabulary-extensible class — no fixed enum to allow lab-specific gradings."@en ;
-    rdfs:domain genomics:SubmitterAssertion .
+    rdfs:domain genomics:SubmitterAssertion ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Review Status (ClinGen / ClinVar 7-tier taxonomy)
@@ -552,13 +628,15 @@ genomics:reviewStatus a owl:ObjectProperty ;
     rdfs:label "Review Status"@en ;
     rdfs:comment "ClinGen / ClinVar review-status classification of this VariantInterpretation, mapping to the 0–4 star confidence rating. Drives advisory engine trust decisions."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range genomics:ReviewStatus .
+    rdfs:range genomics:ReviewStatus ;
+    vs:term_status "unstable" .
 
 genomics:starRating a owl:DatatypeProperty ;
     rdfs:label "Star Rating"@en ;
     rdfs:comment "Integer 0–4 star rating associated with a ReviewStatus, matching ClinVar UI."@en ;
     rdfs:domain genomics:ReviewStatus ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Causality Status (Phenopacket interpretationStatus)
@@ -568,7 +646,8 @@ genomics:interpretationStatus a owl:ObjectProperty ;
     rdfs:label "Interpretation Status (Causality)"@en ;
     rdfs:comment "Whether this variant explains THIS patient's phenotype. Distinct from ACMG classification: ACMG classifies the variant; interpretationStatus classifies the variant's role in the patient's clinical picture. Aligned with GA4GH Phenopackets v2 InterpretationStatus enum."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range genomics:CausalityStatus .
+    rdfs:range genomics:CausalityStatus ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Genetic Test Properties
@@ -578,19 +657,22 @@ genomics:testType a owl:ObjectProperty ;
     rdfs:label "Genetic Test Type"@en ;
     rdfs:comment "Test methodology category. Named-individual values: SingleGeneTest, GenePanelTest, ExomeSequencing, GenomeSequencing, ChromosomalMicroarray, KaryotypeAnalysis, MLPA, RepeatExpansionTest, MethylationStudy, RNASequencing."@en ;
     rdfs:domain genomics:GeneticTest ;
-    rdfs:range genomics:TestType .
+    rdfs:range genomics:TestType ;
+    vs:term_status "unstable" .
 
 genomics:genePanel a owl:DatatypeProperty ;
     rdfs:label "Gene Panel Members"@en ;
     rdfs:comment "Space-separated HGNC symbols for the genes included in this test's analytical scope. Used to distinguish 'no variant found in BRCA1/2' from 'no variant found across a 47-gene cancer panel'."@en ;
     rdfs:domain genomics:GeneticTest ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:variantsObserved a owl:ObjectProperty ;
     rdfs:label "Variants Observed"@en ;
     rdfs:comment "Variants reported by this test. Empty list with non-empty genePanel = clinically meaningful negative result."@en ;
     rdfs:domain genomics:GeneticTest ;
-    rdfs:range genomics:Variant .
+    rdfs:range genomics:Variant ;
+    vs:term_status "unstable" .
 
 # Added in v1-draft.0.2: generic GeneticTest → record predicate. Resolves the
 # HLA tie-break (cascade-coordination/tie-breaks/2026-05-05-task-1.9-hla-variantsObserved.md):
@@ -601,7 +683,8 @@ genomics:variantsObserved a owl:ObjectProperty ;
 genomics:reportedRecord a owl:ObjectProperty ;
     rdfs:label "Reported Record"@en ;
     rdfs:comment "A genomics record (Variant, Haplotype, Diplotype, VariantInterpretation, or other genomics:* class) referenced by this GeneticTest. Use this predicate when the test result is a Diplotype, Haplotype, or PGx implication that has no Variant-typed range. For point-Variant references, prefer the type-specific genomics:variantsObserved (rdfs:range genomics:Variant)."@en ;
-    rdfs:domain genomics:GeneticTest .
+    rdfs:domain genomics:GeneticTest ;
+    vs:term_status "unstable" .
     # No rdfs:range — deliberately broad. SHACL won't constrain the object class
     # so any genomics: record can be referenced.
 
@@ -609,13 +692,15 @@ genomics:orderingProvider a owl:DatatypeProperty ;
     rdfs:label "Ordering Provider"@en ;
     rdfs:comment "Name of clinician who ordered the test. Will become a fhir:Practitioner reference in v1.0."@en ;
     rdfs:domain genomics:GeneticTest ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:performingLab a owl:DatatypeProperty ;
     rdfs:label "Performing Laboratory"@en ;
     rdfs:comment "Name of the laboratory that performed the analysis. Free-text for now; fhir:Organization reference in v1.0."@en ;
     rdfs:domain genomics:GeneticTest ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Genetic Test Order Properties
@@ -625,19 +710,22 @@ genomics:orderedAt a owl:DatatypeProperty ;
     rdfs:label "Ordered At"@en ;
     rdfs:comment "Timestamp when the test was ordered."@en ;
     rdfs:domain genomics:GeneticTestOrder ;
-    rdfs:range xsd:dateTime .
+    rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 genomics:orderStatus a owl:ObjectProperty ;
     rdfs:label "Order Status"@en ;
     rdfs:comment "Status of the test order: Pending, InProgress, Resulted, Cancelled."@en ;
     rdfs:domain genomics:GeneticTestOrder ;
-    rdfs:range genomics:OrderStatus .
+    rdfs:range genomics:OrderStatus ;
+    vs:term_status "unstable" .
 
 genomics:resultedIn a owl:ObjectProperty ;
     rdfs:label "Resulted In"@en ;
     rdfs:comment "Links a fulfilled GeneticTestOrder to the resulting GeneticTest."@en ;
     rdfs:domain genomics:GeneticTestOrder ;
-    rdfs:range genomics:GeneticTest .
+    rdfs:range genomics:GeneticTest ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Sequencing Run Properties (per D-DIRECTORY)
@@ -647,43 +735,50 @@ genomics:coverageDepth a owl:DatatypeProperty ;
     rdfs:label "Coverage Depth"@en ;
     rdfs:comment "Mean coverage depth across the targeted region, e.g. 30.0 for typical clinical WGS. ClinicalGrade tier requires >=30x for WGS or validated panel-specific equivalents."@en ;
     rdfs:domain genomics:SequencingRun ;
-    rdfs:range xsd:decimal .
+    rdfs:range xsd:decimal ;
+    vs:term_status "unstable" .
 
 genomics:sequencingTechnology a owl:ObjectProperty ;
     rdfs:label "Sequencing Technology"@en ;
     rdfs:comment "Sequencing platform/technology category. Named-individual values: ShortReadIllumina, LongReadONT, LongReadPacBio, Mixed, GenotypingArray."@en ;
     rdfs:domain genomics:SequencingRun ;
-    rdfs:range genomics:SequencingTechnology .
+    rdfs:range genomics:SequencingTechnology ;
+    vs:term_status "unstable" .
 
 genomics:variantCallerVersion a owl:DatatypeProperty ;
     rdfs:label "Variant Caller Version"@en ;
     rdfs:comment "Variant caller name and version, e.g. 'GATK 4.5.0', 'DeepVariant 1.6'. Important for reproducibility and for distinguishing caller-driven differences from biological ones."@en ;
     rdfs:domain genomics:SequencingRun ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:laboratoryCertification a owl:ObjectProperty ;
     rdfs:label "Laboratory Certification"@en ;
     rdfs:comment "Regulatory certification of the performing laboratory. Named-individual values: CLIA, CAP, ISO15189, Uncertified."@en ;
     rdfs:domain genomics:SequencingRun ;
-    rdfs:range genomics:LaboratoryCertification .
+    rdfs:range genomics:LaboratoryCertification ;
+    vs:term_status "unstable" .
 
 genomics:sampleCollectionDate a owl:DatatypeProperty ;
     rdfs:label "Sample Collection Date"@en ;
     rdfs:comment "Date the biological sample was collected from the patient."@en ;
     rdfs:domain genomics:SequencingRun ;
-    rdfs:range xsd:date .
+    rdfs:range xsd:date ;
+    vs:term_status "unstable" .
 
 genomics:sequencingDate a owl:DatatypeProperty ;
     rdfs:label "Sequencing Date"@en ;
     rdfs:comment "Date sequencing was performed on the sample."@en ;
     rdfs:domain genomics:SequencingRun ;
-    rdfs:range xsd:date .
+    rdfs:range xsd:date ;
+    vs:term_status "unstable" .
 
 genomics:fileGenerationDate a owl:DatatypeProperty ;
     rdfs:label "File Generation Date"@en ;
     rdfs:comment "Date the raw genomic file (BAM/CRAM/VCF/etc.) was generated. May post-date sequencingDate by re-alignments or re-calls."@en ;
     rdfs:domain genomics:SequencingRun ;
-    rdfs:range xsd:date .
+    rdfs:range xsd:date ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Raw File Properties (pointer-and-hash representation)
@@ -693,37 +788,43 @@ genomics:fileFormat a owl:ObjectProperty ;
     rdfs:label "File Format"@en ;
     rdfs:comment "Raw genomic file format. Named-individual values: BAM, CRAM, FASTQ, gVCF, VCF, BCF, Other. Hot tier (in-pod, encrypted): VCF, gVCF, BCF. Cold tier (out-of-pod, referenced): BAM, CRAM, FASTQ."@en ;
     rdfs:domain genomics:RawFile ;
-    rdfs:range genomics:FileFormat .
+    rdfs:range genomics:FileFormat ;
+    vs:term_status "unstable" .
 
 genomics:fileSizeBytes a owl:DatatypeProperty ;
     rdfs:label "File Size (Bytes)"@en ;
     rdfs:comment "Size of the raw file in bytes. xsd:long because BAM/CRAM/FASTQ files routinely exceed 2^31 bytes (50–100 GB+)."@en ;
     rdfs:domain genomics:RawFile ;
-    rdfs:range xsd:long .
+    rdfs:range xsd:long ;
+    vs:term_status "unstable" .
 
 genomics:fileHashSHA256 a owl:DatatypeProperty ;
     rdfs:label "File SHA-256 Hash"@en ;
     rdfs:comment "Lowercase hex-encoded SHA-256 digest of the file contents. Integrity check enabling the pod to verify the bytes-on-disk match the manifest."@en ;
     rdfs:domain genomics:RawFile ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:fileLocation a owl:DatatypeProperty ;
     rdfs:label "File Location URI"@en ;
     rdfs:comment "Opaque pointer to where the bytes live (s3://, https://, file://, vendor-specific). Cascade does NOT validate or fetch this URI; the bytes live wherever the user keeps them. See Critical conventions #9."@en ;
     rdfs:domain genomics:RawFile ;
-    rdfs:range xsd:anyURI .
+    rdfs:range xsd:anyURI ;
+    vs:term_status "unstable" .
 
 genomics:referenceGenome a owl:DatatypeProperty ;
     rdfs:label "Reference Genome"@en ;
     rdfs:comment "Reference assembly the file is aligned against, e.g. 'GRCh38', 'GRCh37', 'T2T-CHM13'. Required for any downstream coordinate-based analysis."@en ;
     rdfs:domain genomics:RawFile ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:htsgetEndpoint a owl:DatatypeProperty ;
     rdfs:label "htsget Endpoint"@en ;
     rdfs:comment "Optional GA4GH htsget endpoint URI for streaming BAM/CRAM regions on demand without ingesting the full file. Letters labs and cloud-genomics services typically expose htsget; consumer providers usually do not."@en ;
     rdfs:domain genomics:RawFile ;
-    rdfs:range xsd:anyURI .
+    rdfs:range xsd:anyURI ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Data Provenance (genomics-specific enum)
@@ -735,7 +836,8 @@ genomics:htsgetEndpoint a owl:DatatypeProperty ;
 genomics:dataProvenance a owl:ObjectProperty ;
     rdfs:label "Genomic Data Provenance"@en ;
     rdfs:comment "Origin lane of the genomic data, driving importer routing and quality-tier inference. Named-individual values: ConsumerArray, ClinicalSequencing, ResearchSequencing, Imported, AIExtracted. Distinct from the broader cascade:dataProvenance (consumer-vs-clinical classification) — this is genomics-specific because consumer-array imports (Phase 2C) need a distinct lane that auto-tags ConsumerGrade quality."@en ;
-    rdfs:range genomics:DataProvenance .
+    rdfs:range genomics:DataProvenance ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Data Quality Tier (per D-QUALITY-TIER)
@@ -750,13 +852,15 @@ genomics:dataQualityTier a owl:ObjectProperty ;
     rdfs:label "Data Quality Tier"@en ;
     rdfs:comment "Quality tier of the genomic data underlying this Variant, driving downstream advisory and narrative subsystems. Named-individual values: ClinicalGrade, ResearchGrade, ConsumerGrade, UnknownQuality. Aligns with cascadeprotocol.org sequencing-provider directory's three quality criteria (>=30x coverage + raw files + CLIA-certified)."@en ;
     rdfs:domain genomics:Variant ;
-    rdfs:range genomics:DataQualityTier .
+    rdfs:range genomics:DataQualityTier ;
+    vs:term_status "unstable" .
 
 genomics:requiresConfirmation a owl:DatatypeProperty ;
     rdfs:label "Requires Confirmation"@en ;
     rdfs:comment "True when this VariantInterpretation requires confirmatory clinical-grade re-testing before it can drive care decisions. SHACL (TASK-0.2): any Pathogenic / LikelyPathogenic interpretation MUST either reference a ClinicalGrade Variant OR carry requiresConfirmation true. The advisory engine MUST NOT auto-apply care recommendations to confirmation-required interpretations regardless of issuer trust."@en ;
     rdfs:domain genomics:VariantInterpretation ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Phenotype Properties (HPO)
@@ -765,12 +869,14 @@ genomics:requiresConfirmation a owl:DatatypeProperty ;
 genomics:hpoTerm a owl:DatatypeProperty ;
     rdfs:label "HPO Phenotype Term"@en ;
     rdfs:comment "Human Phenotype Ontology term identifier, e.g. 'HP:0003002' (Breast carcinoma). Multiple HPO terms per patient or relative are expected."@en ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:phenotypeOnsetAge a owl:DatatypeProperty ;
     rdfs:label "Phenotype Onset Age"@en ;
     rdfs:comment "Age in years when the phenotype was first observed. Use HPO onset terms (HP:0011462 Young adult onset, etc.) when only categorical onset is known."@en ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Pedigree Classes
@@ -779,13 +885,15 @@ genomics:phenotypeOnsetAge a owl:DatatypeProperty ;
 genomics:Pedigree a owl:Class ;
     rdfs:label "Pedigree"@en ;
     rdfs:comment "A family pedigree: structured representation of relatives with conditions, ages of onset, and (where available) genotypes. Designed to round-trip with HL7 v3 Family History/Pedigree IG and FHIR FamilyMemberHistory while normalizing to Cascade's three-layer model."@en ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 genomics:PedigreeMember a owl:Class ;
     rdfs:label "Pedigree Member"@en ;
     rdfs:comment "A single relative within a pedigree. Distinct from checkup:FamilyHistoryEntry, which is the patient-facing Layer 3 summary; PedigreeMember is the Layer 2 structured record carrying full HPO phenotype set, MONDO disease codes, age of onset/death, sex, and (optionally) carrier or affected status for specific variants."@en ;
     rdfs:subClassOf fhir:FamilyMemberHistory ;
-    rdfs:subClassOf prov:Entity .
+    rdfs:subClassOf prov:Entity ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Pedigree Properties
@@ -795,47 +903,55 @@ genomics:proband a owl:ObjectProperty ;
     rdfs:label "Proband"@en ;
     rdfs:comment "The index patient — the family member who brought the family to clinical attention. Required on every Pedigree."@en ;
     rdfs:domain genomics:Pedigree ;
-    rdfs:range genomics:PedigreeMember .
+    rdfs:range genomics:PedigreeMember ;
+    vs:term_status "unstable" .
 
 genomics:hasMember a owl:ObjectProperty ;
     rdfs:label "Pedigree Member"@en ;
     rdfs:comment "A relative included in the pedigree. Includes the proband."@en ;
     rdfs:domain genomics:Pedigree ;
-    rdfs:range genomics:PedigreeMember .
+    rdfs:range genomics:PedigreeMember ;
+    vs:term_status "unstable" .
 
 genomics:relativeRole a owl:ObjectProperty ;
     rdfs:label "Relationship to Proband"@en ;
     rdfs:comment "HL7 v3 RoleCode-aligned relationship, e.g. MTH (mother), FTH (father), SIS (sister), MGRMTH (maternal grandmother). Cardinal relations are first-class; complex relations expressed via nested PedigreeMember chains."@en ;
     rdfs:domain genomics:PedigreeMember ;
-    rdfs:range genomics:RelationshipRole .
+    rdfs:range genomics:RelationshipRole ;
+    vs:term_status "unstable" .
 
 genomics:relativeSex a owl:DatatypeProperty ;
     rdfs:label "Biological Sex"@en ;
     rdfs:comment "Biological sex of the relative as relevant to inheritance: 'male', 'female', 'unknown'. Distinct from gender identity, which is not modeled here."@en ;
     rdfs:domain genomics:PedigreeMember ;
-    rdfs:range xsd:string .
+    rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 genomics:isDeceased a owl:DatatypeProperty ;
     rdfs:label "Deceased"@en ;
     rdfs:domain genomics:PedigreeMember ;
-    rdfs:range xsd:boolean .
+    rdfs:range xsd:boolean ;
+    vs:term_status "unstable" .
 
 genomics:ageAtDeath a owl:DatatypeProperty ;
     rdfs:label "Age at Death"@en ;
     rdfs:domain genomics:PedigreeMember ;
-    rdfs:range xsd:integer .
+    rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 
 genomics:carrierStatus a owl:ObjectProperty ;
     rdfs:label "Carrier Status for Variant"@en ;
     rdfs:comment "Tested status of this relative for a specific variant (typically the family's known pathogenic variant). Named-individual values: PositiveAffected, PositiveUnaffected, Negative, NotTested, Obligate."@en ;
     rdfs:domain genomics:PedigreeMember ;
-    rdfs:range genomics:CarrierStatus .
+    rdfs:range genomics:CarrierStatus ;
+    vs:term_status "unstable" .
 
 genomics:testedForVariant a owl:ObjectProperty ;
     rdfs:label "Tested for Variant"@en ;
     rdfs:comment "The specific Variant for which this relative's carrierStatus is reported. Allows a relative to have distinct statuses for different variants in the same family."@en ;
     rdfs:domain genomics:PedigreeMember ;
-    rdfs:range genomics:Variant .
+    rdfs:range genomics:Variant ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Named Individuals — ACMG Classification
@@ -1008,15 +1124,18 @@ genomics:Rejected    a genomics:CausalityStatus ; rdfs:label "Rejected"@en ;
 
 genomics:Germline a owl:NamedIndividual, genomics:SomaticStatus ;
     rdfs:label "Germline"@en ;
-    rdfs:comment "Variant present in the germline; inherited or de novo at conception; present in all cells of the individual."@en .
+    rdfs:comment "Variant present in the germline; inherited or de novo at conception; present in all cells of the individual."@en ;
+    vs:term_status "unstable" .
 
 genomics:Somatic a owl:NamedIndividual, genomics:SomaticStatus ;
     rdfs:label "Somatic"@en ;
-    rdfs:comment "Variant acquired post-conception in a specific tissue / cell lineage; not heritable. Common in tumor samples."@en .
+    rdfs:comment "Variant acquired post-conception in a specific tissue / cell lineage; not heritable. Common in tumor samples."@en ;
+    vs:term_status "unstable" .
 
 genomics:UnknownSomaticStatus a owl:NamedIndividual, genomics:SomaticStatus ;
     rdfs:label "Unknown Somatic Status"@en ;
-    rdfs:comment "Origin not determined by the reporting workflow. Use when the source data is silent on germline-vs-somatic classification rather than guessing."@en .
+    rdfs:comment "Origin not determined by the reporting workflow. Use when the source data is silent on germline-vs-somatic classification rather than guessing."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Named Individuals — Sequencing Technology
@@ -1124,7 +1243,8 @@ genomics:AIExtractedGenomics a genomics:DataProvenance ;
 
 genomics:DataQualityTier a owl:Class ;
     rdfs:label "Data Quality Tier"@en ;
-    rdfs:comment "Tier classification of the quality of genomic data, used by the advisory engine to gate auto-applied recommendations and by narrative subsystems to drive disclosure language."@en .
+    rdfs:comment "Tier classification of the quality of genomic data, used by the advisory engine to gate auto-applied recommendations and by narrative subsystems to drive disclosure language."@en ;
+    vs:term_status "unstable" .
 
 genomics:ClinicalGrade a genomics:DataQualityTier ;
     rdfs:label "Clinical Grade"@en ;
@@ -1148,35 +1268,54 @@ genomics:UnknownQuality a genomics:DataQualityTier ;
 
 genomics:loincCode a owl:AnnotationProperty ;
     rdfs:label "LOINC Code Annotation"@en ;
-    rdfs:comment "LOINC code or answer-list URI annotated on a property or named individual to record its Layer 1 standard mapping."@en .
+    rdfs:comment "LOINC code or answer-list URI annotated on a property or named individual to record its Layer 1 standard mapping."@en ;
+    vs:term_status "unstable" .
 
 genomics:loincAnswerCode a owl:AnnotationProperty ;
     rdfs:label "LOINC Answer Code Annotation"@en ;
-    rdfs:comment "LOINC answer code (LA-prefixed string) for an enumerated value, e.g. LA6668-3 = Pathogenic."@en .
+    rdfs:comment "LOINC answer code (LA-prefixed string) for an enumerated value, e.g. LA6668-3 = Pathogenic."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Class Declarations for Named-Individual Ranges
 # ============================================================================
 
-genomics:AcmgClass             a owl:Class ; rdfs:label "ACMG Classification"@en .
-genomics:ZygosityValue         a owl:Class ; rdfs:label "Zygosity Value"@en .
-genomics:PhaseValue            a owl:Class ; rdfs:label "Allelic Phase Value"@en .
-genomics:InheritanceMode       a owl:Class ; rdfs:label "Mode of Inheritance"@en .
-genomics:AllelicRequirement    a owl:Class ; rdfs:label "Allelic Requirement"@en .
-genomics:TestType              a owl:Class ; rdfs:label "Genetic Test Type"@en .
-genomics:CarrierStatus         a owl:Class ; rdfs:label "Carrier Status"@en .
-genomics:RelationshipRole      a owl:Class ; rdfs:label "Pedigree Relationship Role"@en .
-genomics:OrderStatus           a owl:Class ; rdfs:label "Order Status"@en .
-genomics:SubmitterCategory     a owl:Class ; rdfs:label "Submitter Category"@en .
-genomics:ReviewStatus          a owl:Class ; rdfs:label "Review Status"@en .
-genomics:CausalityStatus       a owl:Class ; rdfs:label "Causality Status"@en .
+genomics:AcmgClass             a owl:Class ; rdfs:label "ACMG Classification"@en ;
+    vs:term_status "unstable" .
+genomics:ZygosityValue         a owl:Class ; rdfs:label "Zygosity Value"@en ;
+    vs:term_status "unstable" .
+genomics:PhaseValue            a owl:Class ; rdfs:label "Allelic Phase Value"@en ;
+    vs:term_status "unstable" .
+genomics:InheritanceMode       a owl:Class ; rdfs:label "Mode of Inheritance"@en ;
+    vs:term_status "unstable" .
+genomics:AllelicRequirement    a owl:Class ; rdfs:label "Allelic Requirement"@en ;
+    vs:term_status "unstable" .
+genomics:TestType              a owl:Class ; rdfs:label "Genetic Test Type"@en ;
+    vs:term_status "unstable" .
+genomics:CarrierStatus         a owl:Class ; rdfs:label "Carrier Status"@en ;
+    vs:term_status "unstable" .
+genomics:RelationshipRole      a owl:Class ; rdfs:label "Pedigree Relationship Role"@en ;
+    vs:term_status "unstable" .
+genomics:OrderStatus           a owl:Class ; rdfs:label "Order Status"@en ;
+    vs:term_status "unstable" .
+genomics:SubmitterCategory     a owl:Class ; rdfs:label "Submitter Category"@en ;
+    vs:term_status "unstable" .
+genomics:ReviewStatus          a owl:Class ; rdfs:label "Review Status"@en ;
+    vs:term_status "unstable" .
+genomics:CausalityStatus       a owl:Class ; rdfs:label "Causality Status"@en ;
+    vs:term_status "unstable" .
 genomics:SomaticStatus         a owl:Class ;
     rdfs:label "Somatic Status"@en ;
-    rdfs:comment "Closed enumeration of variant origin classifications (germline / somatic / unknown). Added in v1-draft.0.2."@en .
-genomics:SequencingTechnology  a owl:Class ; rdfs:label "Sequencing Technology"@en .
-genomics:LaboratoryCertification a owl:Class ; rdfs:label "Laboratory Certification"@en .
-genomics:FileFormat            a owl:Class ; rdfs:label "File Format"@en .
-genomics:DataProvenance        a owl:Class ; rdfs:label "Genomic Data Provenance"@en .
+    rdfs:comment "Closed enumeration of variant origin classifications (germline / somatic / unknown). Added in v1-draft.0.2."@en ;
+    vs:term_status "unstable" .
+genomics:SequencingTechnology  a owl:Class ; rdfs:label "Sequencing Technology"@en ;
+    vs:term_status "unstable" .
+genomics:LaboratoryCertification a owl:Class ; rdfs:label "Laboratory Certification"@en ;
+    vs:term_status "unstable" .
+genomics:FileFormat            a owl:Class ; rdfs:label "File Format"@en ;
+    vs:term_status "unstable" .
+genomics:DataProvenance        a owl:Class ; rdfs:label "Genomic Data Provenance"@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Phenotypic Observation (v1-draft.0.4) — index-patient HPO profile
@@ -1185,40 +1324,49 @@ genomics:DataProvenance        a owl:Class ; rdfs:label "Genomic Data Provenance
 genomics:PhenotypicObservation a owl:Class ;
     rdfs:label "Phenotypic Observation"@en ;
     rdfs:comment "A single HPO-coded phenotypic feature observed in the index patient, captured outside the pedigree/variant context (e.g. during conversational phenotype intake). Supports negated findings (phenotype explicitly absent), essential for narrowing a differential. Provenance is typically cascade:SelfReported. Reuses genomics:hpoTerm for the HPO linkage."@en ;
-    owl:versionInfo "Added in genomics v1-draft.0.4" .
+    owl:versionInfo "Added in genomics v1-draft.0.4" ;
+    vs:term_status "unstable" .
 
 genomics:PhenotypePresenceValue a owl:Class ;
     rdfs:label "Phenotype Presence Value"@en ;
     rdfs:comment "Closed enumeration: whether the phenotype is present, absent, or resolved."@en ;
-    owl:versionInfo "Added in genomics v1-draft.0.4" .
+    owl:versionInfo "Added in genomics v1-draft.0.4" ;
+    vs:term_status "unstable" .
 
-genomics:Present  a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Present"@en .
+genomics:Present  a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Present"@en ;
+    vs:term_status "unstable" .
 genomics:Absent   a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Absent"@en ;
-    rdfs:comment "Phenotype explicitly assessed and NOT present (negated finding)."@en .
-genomics:Resolved a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Resolved"@en .
+    rdfs:comment "Phenotype explicitly assessed and NOT present (negated finding)."@en ;
+    vs:term_status "unstable" .
+genomics:Resolved a owl:NamedIndividual, genomics:PhenotypePresenceValue ; rdfs:label "Resolved"@en ;
+    vs:term_status "unstable" .
 
 genomics:phenotypePresence a owl:ObjectProperty ;
     rdfs:label "Phenotype Presence"@en ;
     rdfs:domain genomics:PhenotypicObservation ;
     rdfs:range genomics:PhenotypePresenceValue ;
-    owl:versionInfo "Added in genomics v1-draft.0.4" .
+    owl:versionInfo "Added in genomics v1-draft.0.4" ;
+    vs:term_status "unstable" .
 
 genomics:phenotypeOnsetDate a owl:DatatypeProperty ;
     rdfs:label "Phenotype Onset Date"@en ;
     rdfs:comment "Calendar date the phenotype was first observed. Use genomics:phenotypeOnsetAge for age-based onset."@en ;
     rdfs:domain genomics:PhenotypicObservation ;
     rdfs:range xsd:date ;
-    owl:versionInfo "Added in genomics v1-draft.0.4" .
+    owl:versionInfo "Added in genomics v1-draft.0.4" ;
+    vs:term_status "unstable" .
 
 genomics:phenotypeSeverity a owl:DatatypeProperty ;
     rdfs:label "Phenotype Severity"@en ;
     rdfs:comment "Optional HPO severity modifier: mild, moderate, severe, profound (HP:0012823 modifier space)."@en ;
     rdfs:domain genomics:PhenotypicObservation ;
     rdfs:range xsd:string ;
-    owl:versionInfo "Added in genomics v1-draft.0.4" .
+    owl:versionInfo "Added in genomics v1-draft.0.4" ;
+    vs:term_status "unstable" .
 
 genomics:phenotypeNote a owl:DatatypeProperty ;
     rdfs:label "Phenotype Note"@en ;
     rdfs:domain genomics:PhenotypicObservation ;
     rdfs:range xsd:string ;
-    owl:versionInfo "Added in genomics v1-draft.0.4" .
+    owl:versionInfo "Added in genomics v1-draft.0.4" ;
+    vs:term_status "unstable" .

--- a/ontologies/workbench/v1-draft/workbench.ttl
+++ b/ontologies/workbench/v1-draft/workbench.ttl
@@ -104,6 +104,18 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix ical: <http://www.w3.org/2002/12/cal/ical#> .
 
+@prefix vs:        <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+# ============================================================================
+# Changelog
+# ============================================================================
+# v1.0-draft.0.7 (2026-08-20) — Per-term maturity. Every term now carries
+#   vs:term_status (W3C SemWeb Vocabulary Status, originating in FOAF):
+#   "unstable" for draft terms, "archaic" for terms already marked
+#   owl:deprecated. The convention is per-TERM by design, so a vocabulary
+#   can promote individual terms in place without a namespace change;
+#   Cascade previously stated maturity once per vocabulary, in prose no
+#   machine could read. No term definition changed.
+
 # ============================================================================
 # Ontology Metadata
 # ============================================================================
@@ -113,8 +125,8 @@
     dct:description "Layer 3 vocabulary for the Cascade Workbench desktop investigation app."@en ;
     dct:creator "Cascade Agentic Labs" ;
     dct:created "2026-06-16"^^xsd:date ;
-    dct:modified "2026-08-18"^^xsd:date ;
-    owl:versionInfo "1.0-draft.0.6" ;
+    dct:modified "2026-08-20"^^xsd:date ;
+    owl:versionInfo "1.0-draft.0.7" ;
     rdfs:comment "Holds the app-specific workspace objects only: Investigation, ImportedConversation, Hypothesis, Pin, InvestigationNote, plus the append-only record-amendment overlays (Amendment, Annotation, Retraction, Tombstone). The assertion/evidence/verdict grounding model is deliberately NOT here (it is cross-cutting Layer 2 evidence:). Phenotype capture is NOT here (it extends genomics:). Per the Layer 3 graduation rule, any class here that proves useful to other apps should graduate to Layer 2. Draft: not in VOCAB_VERSIONS until v1.0 graduation."@en ;
     rdfs:seeAlso <https://cascadeprotocol.org/docs/workbench/v1-draft/> .
 
@@ -125,84 +137,109 @@
 workbench:Investigation a owl:Class ;
     rdfs:label "Investigation"@en ;
     rdfs:comment "A named, longitudinal inquiry over one patient's Pod: the top-level workspace object. Aggregates imported conversations, hypotheses, pinned evidence, and notes over time. Only the Workbench UI touches this class directly."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.1" .
+    owl:versionInfo "Added in workbench v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 workbench:ImportedConversation a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Imported Conversation"@en ;
     rdfs:comment "A conversation the user had with a general-purpose AI assistant (ChatGPT, Claude, Gemini, etc.), imported into an Investigation as a source. Discrete assertions extracted from it are evidence:Assertion instances produced by a cascade:AIExtractionActivity; those assertions carry cascade:dataProvenance cascade:AIAsserted (ungrounded by construction until graded)."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.1" .
+    owl:versionInfo "Added in workbench v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 workbench:Hypothesis a owl:Class ;
     rdfs:label "Hypothesis"@en ;
     rdfs:comment "A candidate explanation under active consideration in an Investigation, with a lifecycle status. Designed to support widening the differential and explicitly retiring or excluding hypotheses, not just confirming one."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.1" .
+    owl:versionInfo "Added in workbench v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 workbench:Pin a owl:Class ;
     rdfs:label "Pin"@en ;
     rdfs:comment "A curated bookmark within an Investigation pointing at any resource (a record, an assertion, a citation) with an optional note. The mechanism by which the user assembles evidence NotebookLM-style."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.1" .
+    owl:versionInfo "Added in workbench v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 workbench:InvestigationStatusValue a owl:Class ;
     rdfs:label "Investigation Status Value"@en ;
     rdfs:comment "Closed enumeration of Investigation lifecycle states."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.1" .
+    owl:versionInfo "Added in workbench v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 workbench:HypothesisStatusValue a owl:Class ;
     rdfs:label "Hypothesis Status Value"@en ;
     rdfs:comment "Closed enumeration of Hypothesis lifecycle states."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.1" .
+    owl:versionInfo "Added in workbench v1-draft.0.1" ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Named Individuals (enumerations)
 # ============================================================================
 
-workbench:Active   a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Active"@en .
-workbench:Paused   a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Paused"@en .
-workbench:Resolved a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Resolved"@en .
-workbench:Archived a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Archived"@en .
+workbench:Active   a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Active"@en ;
+    vs:term_status "unstable" .
+workbench:Paused   a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Paused"@en ;
+    vs:term_status "unstable" .
+workbench:Resolved a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Resolved"@en ;
+    vs:term_status "unstable" .
+workbench:Archived a owl:NamedIndividual, workbench:InvestigationStatusValue ; rdfs:label "Archived"@en ;
+    vs:term_status "unstable" .
 
-workbench:Proposed  a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Proposed"@en .
-workbench:Supported a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Supported"@en .
+workbench:Proposed  a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Proposed"@en ;
+    vs:term_status "unstable" .
+workbench:Supported a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Supported"@en ;
+    vs:term_status "unstable" .
 workbench:Retired   a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Retired"@en ;
-    rdfs:comment "No longer pursued; kept for the record (not deleted)."@en .
+    rdfs:comment "No longer pursued; kept for the record (not deleted)."@en ;
+    vs:term_status "unstable" .
 workbench:Excluded  a owl:NamedIndividual, workbench:HypothesisStatusValue ; rdfs:label "Excluded"@en ;
-    rdfs:comment "Actively ruled out by evidence."@en .
+    rdfs:comment "Actively ruled out by evidence."@en ;
+    vs:term_status "unstable" .
 
 workbench:Unverified a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Unverified"@en ;
-    rdfs:comment "Not corroborated by a clinician or authoritative source. The default for patient self-entered data. Maps to FHIR verificationStatus 'unconfirmed'."@en .
+    rdfs:comment "Not corroborated by a clinician or authoritative source. The default for patient self-entered data. Maps to FHIR verificationStatus 'unconfirmed'."@en ;
+    vs:term_status "unstable" .
 workbench:Confirmed  a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Confirmed"@en ;
-    rdfs:comment "Corroborated. Maps to FHIR verificationStatus 'confirmed'."@en .
+    rdfs:comment "Corroborated. Maps to FHIR verificationStatus 'confirmed'."@en ;
+    vs:term_status "unstable" .
 workbench:Refuted    a owl:NamedIndividual, workbench:VerificationStatusValue ; rdfs:label "Refuted"@en ;
-    rdfs:comment "Disproved on review. Maps to FHIR verificationStatus 'refuted'."@en .
+    rdfs:comment "Disproved on review. Maps to FHIR verificationStatus 'refuted'."@en ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Properties — Investigation
 # ============================================================================
 
 workbench:investigationTitle a owl:DatatypeProperty ; rdfs:label "investigation title"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range xsd:string .
+    rdfs:domain workbench:Investigation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 workbench:aboutPatient a owl:ObjectProperty ;
     rdfs:subPropertyOf prov:wasAttributedTo ;
     rdfs:label "about patient"@en ;
     rdfs:comment "The patient (profile/card.ttl WebID) this Investigation concerns. With caregiver-proxy, the operating agent is recorded separately via cascade:ProxyAgent."@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range rdfs:Resource .
+    rdfs:domain workbench:Investigation ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 
 workbench:investigationStatus a owl:ObjectProperty ; rdfs:label "investigation status"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range workbench:InvestigationStatusValue .
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:InvestigationStatusValue ;
+    vs:term_status "unstable" .
 
 workbench:createdAt a owl:DatatypeProperty ; rdfs:label "created at"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range xsd:dateTime .
+    rdfs:domain workbench:Investigation ; rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 workbench:updatedAt a owl:DatatypeProperty ; rdfs:label "updated at"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range xsd:dateTime .
+    rdfs:domain workbench:Investigation ; rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 
 workbench:containsConversation a owl:ObjectProperty ; rdfs:label "contains conversation"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range workbench:ImportedConversation .
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:ImportedConversation ;
+    vs:term_status "unstable" .
 workbench:hasHypothesis a owl:ObjectProperty ; rdfs:label "has hypothesis"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range workbench:Hypothesis .
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:Hypothesis ;
+    vs:term_status "unstable" .
 workbench:hasPin a owl:ObjectProperty ; rdfs:label "has pin"@en ;
-    rdfs:domain workbench:Investigation ; rdfs:range workbench:Pin .
+    rdfs:domain workbench:Investigation ; rdfs:range workbench:Pin ;
+    vs:term_status "unstable" .
 # (workbench:hasNote / workbench:InvestigationNote removed in v1-draft.0.5:
 #  an investigation-scoped note is an oa:Annotation targeting the
 #  Investigation — see the Web Annotation substrate section below.)
@@ -213,30 +250,39 @@ workbench:hasPin a owl:ObjectProperty ; rdfs:label "has pin"@en ;
 
 workbench:conversationSource a owl:DatatypeProperty ; rdfs:label "conversation source"@en ;
     rdfs:comment "Originating assistant, e.g. 'chatgpt', 'claude', 'gemini', 'other'."@en ;
-    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:string .
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:importedAt a owl:DatatypeProperty ; rdfs:label "imported at"@en ;
-    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:dateTime .
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:dateTime ;
+    vs:term_status "unstable" .
 workbench:messageCount a owl:DatatypeProperty ; rdfs:label "message count"@en ;
-    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:integer .
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:integer ;
+    vs:term_status "unstable" .
 workbench:rawContentLocation a owl:DatatypeProperty ; rdfs:label "raw content location"@en ;
     rdfs:comment "Pod-relative path to the stored raw conversation (recommended path sources/)."@en ;
-    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:string .
+    rdfs:domain workbench:ImportedConversation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:extractedAssertion a owl:ObjectProperty ; rdfs:label "extracted assertion"@en ;
     rdfs:comment "An evidence:Assertion decomposed from this conversation."@en ;
-    rdfs:domain workbench:ImportedConversation ; rdfs:range evidence:Assertion .
+    rdfs:domain workbench:ImportedConversation ; rdfs:range evidence:Assertion ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Properties — Hypothesis
 # ============================================================================
 
 workbench:hypothesisLabel a owl:DatatypeProperty ; rdfs:label "hypothesis label"@en ;
-    rdfs:domain workbench:Hypothesis ; rdfs:range xsd:string .
+    rdfs:domain workbench:Hypothesis ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:hypothesisStatus a owl:ObjectProperty ; rdfs:label "hypothesis status"@en ;
-    rdfs:domain workbench:Hypothesis ; rdfs:range workbench:HypothesisStatusValue .
+    rdfs:domain workbench:Hypothesis ; rdfs:range workbench:HypothesisStatusValue ;
+    vs:term_status "unstable" .
 workbench:supportedByAssertion a owl:ObjectProperty ; rdfs:label "supported by assertion"@en ;
-    rdfs:domain workbench:Hypothesis ; rdfs:range evidence:Assertion .
+    rdfs:domain workbench:Hypothesis ; rdfs:range evidence:Assertion ;
+    vs:term_status "unstable" .
 workbench:refutedByAssertion a owl:ObjectProperty ; rdfs:label "refuted by assertion"@en ;
-    rdfs:domain workbench:Hypothesis ; rdfs:range evidence:Assertion .
+    rdfs:domain workbench:Hypothesis ; rdfs:range evidence:Assertion ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Properties — Pin
@@ -244,9 +290,11 @@ workbench:refutedByAssertion a owl:ObjectProperty ; rdfs:label "refuted by asser
 
 workbench:pinnedResource a owl:ObjectProperty ; rdfs:label "pinned resource"@en ;
     rdfs:comment "Any resource pinned into the Investigation. Open range for cross-namespace linking."@en ;
-    rdfs:domain workbench:Pin ; rdfs:range rdfs:Resource .
+    rdfs:domain workbench:Pin ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 workbench:pinNote a owl:DatatypeProperty ; rdfs:label "pin note"@en ;
-    rdfs:domain workbench:Pin ; rdfs:range xsd:string .
+    rdfs:domain workbench:Pin ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Notes, research flags, and follow-ups — the W3C Web Annotation substrate
@@ -290,7 +338,8 @@ workbench:followUp a owl:NamedIndividual, oa:Motivation ;
     skos:prefLabel "follow up"@en ;
     skos:broader oa:questioning ;
     rdfs:comment "The motivation of a follow-up / open loop: an annotation that names something the caregiver intends to resolve later (e.g. \"recheck TSH in 3 months\"). Minted per the Web Annotation model's extension rule (a custom motivation SHOULD be a skos:Concept with skos:broader to a standard one); oa:questioning is the nearest standard motivation — an open question awaiting resolution. An annotation motivated by workbench:followUp is dual-typed cal:Vtodo and carries ical:status (required) + ical:due (optional). Candidate to graduate to a shared layer if other Cascade apps adopt the open-loops worklist."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.5" .
+    owl:versionInfo "Added in workbench v1-draft.0.5" ;
+    vs:term_status "unstable" .
 
 # ============================================================================
 # Append-only record amendment overlays
@@ -306,30 +355,35 @@ workbench:Amendment a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Amendment"@en ;
     rdfs:comment "An append-only overlay that overrides one property value on an existing record without mutating the original. Names the amended record, the predicate CURIE being overridden, and the new value. Discovered at query time so the effective value can be projected over the immutable original."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.2" .
+    owl:versionInfo "Added in workbench v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 workbench:Annotation a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Annotation"@en ;
     rdfs:comment "An append-only overlay that ADDS a note or an extra attribute to an existing record without overriding any of its values. Use Amendment to override; use Annotation to augment."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.2" .
+    owl:versionInfo "Added in workbench v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 workbench:Retraction a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Retraction"@en ;
     rdfs:comment "An append-only soft-delete / supersede overlay (the entered-in-error pattern). The retracted record's bytes are retained; the Retraction marks it as withdrawn and may point at the kept record when merging duplicates."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.2" .
+    owl:versionInfo "Added in workbench v1-draft.0.2" ;
+    vs:term_status "unstable" .
 
 workbench:Tombstone a owl:Class ;
     rdfs:subClassOf prov:Entity ;
     rdfs:label "Tombstone"@en ;
     rdfs:comment "A content-free hard-erase audit marker. Unlike a Retraction, the erased record's bytes are gone from its bucket file; the Tombstone records only the EVENT of erasure — the erased record's opaque id, the actor (prov:wasAttributedTo), the timestamp (dct:created), and the action (workbench:erasureAction) — so the deletion is provably logged WITHOUT retaining any content of the erased record. It deliberately holds no content hash: a hash of an erased record's triples is still pseudonymised personal data (low-entropy health content is brute-forceable), which would re-create the erasure obligation the hard-erase just discharged."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.2; contentHash removed, erasureAction added in v1-draft.0.3" .
+    owl:versionInfo "Added in workbench v1-draft.0.2; contentHash removed, erasureAction added in v1-draft.0.3" ;
+    vs:term_status "unstable" .
 
 workbench:VerificationStatusValue a owl:Class ;
     rdfs:label "Verification Status Value"@en ;
     rdfs:comment "Closed enumeration of a record's clinical verification state — the VERIFICATION axis, orthogonal to the SOURCE axis (cascade:dataProvenance). Mirrors FHIR AllergyIntolerance/Condition.verificationStatus. Candidate to graduate to clinical:/Layer 2."@en ;
-    owl:versionInfo "Added in workbench v1-draft.0.3" .
+    owl:versionInfo "Added in workbench v1-draft.0.3" ;
+    vs:term_status "unstable" .
 
 # ── Properties shared by all overlay classes ────────────────────────────────
 # (cascade:dataProvenance, prov:wasAttributedTo, and dct:created are reused
@@ -339,72 +393,89 @@ workbench:VerificationStatusValue a owl:Class ;
 
 workbench:amendsRecord a owl:ObjectProperty ; rdfs:label "amends record"@en ;
     rdfs:comment "The existing record whose property value this Amendment overrides."@en ;
-    rdfs:domain workbench:Amendment ; rdfs:range rdfs:Resource .
+    rdfs:domain workbench:Amendment ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 workbench:amendsProperty a owl:DatatypeProperty ; rdfs:label "amends property"@en ;
     rdfs:comment "The predicate CURIE being overridden, e.g. \"clinical:dosage\"."@en ;
-    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:amendedValue a owl:DatatypeProperty ; rdfs:label "amended value"@en ;
     rdfs:comment "The new value that supersedes the original value of amendsProperty."@en ;
-    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:amendmentReason a owl:DatatypeProperty ; rdfs:label "amendment reason"@en ;
     rdfs:comment "Optional free-text rationale for the amendment."@en ;
-    rdfs:domain workbench:Amendment ; rdfs:range xsd:string .
+    rdfs:domain workbench:Amendment ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ── Properties — Annotation ─────────────────────────────────────────────────
 
 workbench:annotatesRecord a owl:ObjectProperty ; rdfs:label "annotates record"@en ;
     rdfs:comment "The existing record this Annotation augments."@en ;
-    rdfs:domain workbench:Annotation ; rdfs:range rdfs:Resource .
+    rdfs:domain workbench:Annotation ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 workbench:annotationText a owl:DatatypeProperty ; rdfs:label "annotation text"@en ;
     rdfs:comment "Optional free-text note attached to the record."@en ;
-    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:annotationProperty a owl:DatatypeProperty ; rdfs:label "annotation property"@en ;
     rdfs:comment "Optional predicate CURIE of an extra attribute being added (paired with annotationValue)."@en ;
-    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:annotationValue a owl:DatatypeProperty ; rdfs:label "annotation value"@en ;
     rdfs:comment "Optional value of the extra attribute named by annotationProperty."@en ;
-    rdfs:domain workbench:Annotation ; rdfs:range xsd:string .
+    rdfs:domain workbench:Annotation ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ── Properties — Retraction ─────────────────────────────────────────────────
 
 workbench:retractsRecord a owl:ObjectProperty ; rdfs:label "retracts record"@en ;
     rdfs:comment "The existing record this Retraction soft-deletes / supersedes."@en ;
-    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource .
+    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 workbench:retractionReason a owl:DatatypeProperty ; rdfs:label "retraction reason"@en ;
     rdfs:comment "Optional free-text rationale (e.g. \"entered in error\")."@en ;
-    rdfs:domain workbench:Retraction ; rdfs:range xsd:string .
+    rdfs:domain workbench:Retraction ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:supersededBy a owl:ObjectProperty ; rdfs:label "superseded by"@en ;
     rdfs:comment "Optional pointer to the kept record when merging duplicates."@en ;
-    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource .
+    rdfs:domain workbench:Retraction ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 
 # ── Properties — Tombstone ──────────────────────────────────────────────────
 
 workbench:erasedRecord a owl:ObjectProperty ; rdfs:label "erased record"@en ;
     rdfs:comment "The id of the record whose bytes were hard-erased from its bucket file."@en ;
-    rdfs:domain workbench:Tombstone ; rdfs:range rdfs:Resource .
+    rdfs:domain workbench:Tombstone ; rdfs:range rdfs:Resource ;
+    vs:term_status "unstable" .
 workbench:erasedType a owl:DatatypeProperty ; rdfs:label "erased type"@en ;
     rdfs:comment "Optional rdf:type CURIE of the erased record (a category, e.g. \"clinical:Medication\"), retained for audit. Category-level only — it names the kind of record erased, never its content."@en ;
-    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:erasureAction a owl:DatatypeProperty ; rdfs:label "erasure action"@en ;
     rdfs:comment "The action this Tombstone records, e.g. \"hard-erase\". Makes the Tombstone a self-describing, content-free audit event."@en ;
-    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 workbench:erasureReason a owl:DatatypeProperty ; rdfs:label "erasure reason"@en ;
     rdfs:comment "Optional free-text rationale for the hard erasure (author-supplied; keep content-free to preserve the erasure)."@en ;
-    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string .
+    rdfs:domain workbench:Tombstone ; rdfs:range xsd:string ;
+    vs:term_status "unstable" .
 
 # ── Properties — Verification axis (orthogonal to cascade:dataProvenance) ─────
 
 workbench:verificationStatus a owl:ObjectProperty ; rdfs:label "verification status"@en ;
     rdfs:comment "A record's clinical verification state (VERIFICATION axis), independent of who reported it (SOURCE axis, cascade:dataProvenance). Open domain so it can tag any record; patient self-entered records default to workbench:Unverified."@en ;
     rdfs:range workbench:VerificationStatusValue ;
-    owl:versionInfo "Added in workbench v1-draft.0.3" .
+    owl:versionInfo "Added in workbench v1-draft.0.3" ;
+    vs:term_status "unstable" .
 
 # ── Properties — Filing / organization axis (orthogonal to the imported origin) ─
 
 workbench:userSourceLabel a owl:DatatypeProperty ; rdfs:label "user source label"@en ;
     rdfs:comment "The user-chosen FILING label for the SOURCE a record is organized under in the Workbench 'filing cabinet' (the ORGANIZATION axis). It is a filing PREFERENCE attributed to the user, carried on a workbench:Annotation (annotationProperty = \"workbench:userSourceLabel\", annotationValue = the chosen label) whose overlay bears cascade:SelfReported provenance. It MUST NOT alter the objective imported origin clinical:sourceEHR, which is preserved and displayed alongside. The effective source the UI groups records by prefers this label when present, else falls back to the imported origin (clinical:sourceEHR, else the import-batch tag). Open domain (like workbench:verificationStatus) so it can file any record."@en ;
     rdfs:range xsd:string ;
-    owl:versionInfo "Added in workbench v1-draft.0.4" .
+    owl:versionInfo "Added in workbench v1-draft.0.4" ;
+    vs:term_status "unstable" .
 
 # ── Properties — Curation axes (effective-view projection state) ────────────
 # Added in workbench v1-draft.0.6. Three flags carried on workbench:Annotation
@@ -420,14 +491,17 @@ workbench:userSourceLabel a owl:DatatypeProperty ; rdfs:label "user source label
 workbench:problemListCuration a owl:DatatypeProperty ; rdfs:label "problem list curation"@en ;
     rdfs:comment "The user's ruling on whether a condition cluster belongs on the effective problem list. Closed token set: \"included\" / \"excluded\". Targets a member record of the cluster; resolution is the latest overlay by dct:created across all of the cluster's member records. Distinct from clinical truth: an excluded condition's records remain intact and visible in receipts views."@en ;
     rdfs:range xsd:string ;
-    owl:versionInfo "Added in workbench v1-draft.0.6" .
+    owl:versionInfo "Added in workbench v1-draft.0.6" ;
+    vs:term_status "unstable" .
 
 workbench:recordVisibility a owl:DatatypeProperty ; rdfs:label "record visibility"@en ;
     rdfs:comment "A user's non-destructive visibility preference for one record in effective views. Closed token set: \"hidden\" / \"visible\". Hiding is an append-only overlay and unhiding is a later overlay, never a deletion; the record remains in its bucket and in receipts views. Distinct from workbench:Retraction (entered in error, superseded) and workbench:Tombstone (erasure): a hidden record is still asserted as true, the user just does not want it in the way. Discharged when its record is superseded by a duplicate merge: hiding is a statement about the copy that was hidden, and the surviving record's own visibility governs, so a hidden duplicate never silently hides the record the user chose to keep."@en ;
     rdfs:range xsd:string ;
-    owl:versionInfo "Added in workbench v1-draft.0.6" .
+    owl:versionInfo "Added in workbench v1-draft.0.6" ;
+    vs:term_status "unstable" .
 
 workbench:recordImportance a owl:DatatypeProperty ; rdfs:label "record importance"@en ;
     rdfs:comment "A user salience flag on one record. Closed token set: \"important\" / \"normal\". Marks the record as a priority retrieval key for downstream queries and agent searches; it carries no further semantics. Follows the surviving record across a duplicate merge: salience is about the fact, not the copy."@en ;
     rdfs:range xsd:string ;
-    owl:versionInfo "Added in workbench v1-draft.0.6" .
+    owl:versionInfo "Added in workbench v1-draft.0.6" ;
+    vs:term_status "unstable" .

--- a/scripts/check-term-status.py
+++ b/scripts/check-term-status.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""check-term-status.py — every draft term must declare a valid vs:term_status.
+
+Run from the spec repo root:
+    python3 scripts/check-term-status.py                 # all draft vocabularies
+    python3 scripts/check-term-status.py path/to/x.ttl   # specific files
+
+WHY THIS EXISTS
+---------------
+Cascade used to state maturity once per VOCABULARY, in prose. The W3C SemWeb
+Vocabulary Status ontology (http://www.w3.org/2003/06/sw-vocab-status/ns#,
+originating in FOAF) states it per TERM, and its own description says why:
+recording status at the term level rather than the vocabulary level makes
+fine-grained improvement easier. That is precisely the guarantee a /v1#
+namespace already makes, so a vocabulary can promote individual terms in place
+without minting a new namespace. Adopted 2026-08-20 across the five draft
+vocabularies.
+
+It is CHECKED rather than trusted because the pass that added these annotations
+silently skipped 96 of 411 terms -- every term that happened to be preceded by a
+section comment -- and reported success. A tool's own count of what it did is
+not evidence. This reads the parsed graph instead.
+
+Values are the four the ontology defines: unstable, testing, stable, archaic.
+A term marked owl:deprecated must be archaic; that is the one pairing the two
+vocabularies both have an opinion about, and disagreeing would leave a consumer
+with two contradictory machine-readable answers.
+"""
+
+import glob
+import sys
+
+from rdflib import Graph, Namespace, URIRef
+from rdflib.namespace import OWL, RDF
+
+VS = Namespace("http://www.w3.org/2003/06/sw-vocab-status/ns#")
+TERM_STATUS = VS.term_status
+
+TERM_TYPES = {
+    OWL.Class,
+    OWL.ObjectProperty,
+    OWL.DatatypeProperty,
+    OWL.AnnotationProperty,
+    OWL.NamedIndividual,
+    URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"),
+}
+
+VALID = {"unstable", "testing", "stable", "archaic"}
+
+
+def local(term):
+    s = str(term)
+    return s.rsplit("#", 1)[-1] if "#" in s else s.rsplit("/", 1)[-1]
+
+
+def check(path):
+    g = Graph()
+    g.parse(path, format="turtle")
+
+    terms = {s for s, _, o in g.triples((None, RDF.type, None))
+             if o in TERM_TYPES and isinstance(s, URIRef)}
+    # The ontology header declares itself owl:Ontology, not a term type, so it
+    # is already excluded and must stay that way: its maturity is versionInfo.
+
+    missing, bad, deprecated_not_archaic = [], [], []
+    for term in sorted(terms):
+        values = [str(o) for o in g.objects(term, TERM_STATUS)]
+        if not values:
+            missing.append(term)
+            continue
+        for v in values:
+            if v not in VALID:
+                bad.append((term, v))
+        if (term, OWL.deprecated, None) in g:
+            if any(bool(o) for o in g.objects(term, OWL.deprecated)):
+                if "archaic" not in values:
+                    deprecated_not_archaic.append((term, values))
+
+    name = path.rsplit("/", 1)[-1]
+    print(f"{name:22s} {len(terms):4d} terms, "
+          f"{len(terms) - len(missing):4d} with status, {len(missing):3d} missing")
+    for t in missing[:25]:
+        print(f"      MISSING vs:term_status: {local(t)}", file=sys.stderr)
+    for t, v in bad:
+        print(f"      INVALID value {v!r} on {local(t)} "
+              f"(expected one of {sorted(VALID)})", file=sys.stderr)
+    for t, v in deprecated_not_archaic:
+        print(f"      owl:deprecated but term_status {v} on {local(t)} "
+              f"(expected archaic)", file=sys.stderr)
+    return len(missing) + len(bad) + len(deprecated_not_archaic)
+
+
+def main():
+    paths = sys.argv[1:]
+    if not paths:
+        paths = sorted(p for p in glob.glob("ontologies/*/v1-draft/*.ttl")
+                       if not p.endswith(".shapes.ttl"))
+    if not paths:
+        print("Error: no draft ontologies found. Run from the spec repo root.",
+              file=sys.stderr)
+        return 1
+
+    problems = sum(check(p) for p in paths)
+    print()
+    if problems:
+        print(f"FAILED: {problems} problem(s).", file=sys.stderr)
+        return 1
+    print("All draft terms declare a valid vs:term_status.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-check-term-status.sh
+++ b/scripts/test-check-term-status.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# test-check-term-status.sh
+#
+# Regression suite for check-term-status.py.
+#
+# The defect under test: a draft vocabulary states its maturity once, in prose,
+# so a consumer cannot tell which individual terms are safe to build on. The fix
+# is vs:term_status on every term. The risk is that the annotation pass MISSES
+# terms and nobody notices, which is not hypothetical: the pass that introduced
+# these annotations silently skipped 96 of 411 terms -- every term preceded by a
+# section comment -- and reported success. Only reading the parsed graph caught
+# it. See scripts/check-term-status.py.
+#
+# Every assertion below is paired with a NEGATIVE CONTROL: a scratch copy of a
+# real ontology with one defect deliberately reintroduced, which the check must
+# catch and must name. A check that has only ever been observed passing is not
+# evidence that it can fail.
+#
+# The suite also proves the check is not vacuous: run against a corpus with no
+# terms at all, it must report FAIL because it examined nothing, rather than
+# PASS because it found nothing to complain about.
+#
+# Usage: ./scripts/test-check-term-status.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SPEC_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK="$SCRIPT_DIR/check-term-status.py"
+PYTHON="${PYTHON:-python3}"
+
+PASSED=0
+FAILED=0
+
+pass() { PASSED=$((PASSED + 1)); echo "  PASS  $1"; }
+fail() { FAILED=$((FAILED + 1)); echo "  FAIL  $1"; echo "        $2"; }
+
+# A missing parser is a hard failure, never a skip. Skipping the suite because a
+# dependency is absent reports green while testing nothing, which is the exact
+# class of defect this file guards against.
+if ! "$PYTHON" -c "import rdflib" 2>/dev/null; then
+  echo "ERROR: $PYTHON cannot import rdflib, so this suite would test nothing."
+  echo "       Install it:  $PYTHON -m pip install -r scripts/requirements.txt"
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+SUBJECT="$SPEC_ROOT/ontologies/workbench/v1-draft/workbench.ttl"
+
+echo "check-term-status.py regression suite"
+echo ""
+
+# ── 1. The repository itself passes ───────────────────────────────────────────
+if (cd "$SPEC_ROOT" && "$PYTHON" "$CHECK" >/dev/null 2>&1); then
+  pass "every draft term in this repository declares a vs:term_status"
+else
+  (cd "$SPEC_ROOT" && "$PYTHON" "$CHECK" 2>&1 | tail -20)
+  fail "every draft term in this repository declares a vs:term_status" \
+       "the check reports a problem against unmodified sources"
+fi
+
+# ── 2. Negative control: a term with its status removed ───────────────────────
+# The exact defect the first annotation pass shipped.
+cp "$SUBJECT" "$WORK/missing.ttl"
+"$PYTHON" - "$WORK/missing.ttl" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+s = p.read_text(encoding="utf-8")
+old = ' ;\n    vs:term_status "unstable" .'
+assert s.count(old) > 0, "fixture no longer contains an annotated term"
+p.write_text(s.replace(old, ' .', 1), encoding="utf-8")
+PY
+OUT="$("$PYTHON" "$CHECK" "$WORK/missing.ttl" 2>&1)"
+if [ $? -ne 0 ] && echo "$OUT" | grep -q "MISSING vs:term_status"; then
+  pass "a term with no vs:term_status is caught and named"
+else
+  fail "a term with no vs:term_status is caught and named" \
+       "check did not fail, or did not name the term: $OUT"
+fi
+
+# ── 3. Negative control: an unrecognised status value ─────────────────────────
+cp "$SUBJECT" "$WORK/badvalue.ttl"
+sed 's/vs:term_status "unstable"/vs:term_status "prettystable"/' "$SUBJECT" > "$WORK/badvalue.ttl"
+OUT="$("$PYTHON" "$CHECK" "$WORK/badvalue.ttl" 2>&1)"
+if [ $? -ne 0 ] && echo "$OUT" | grep -q "INVALID value"; then
+  pass "a status outside {unstable,testing,stable,archaic} is caught"
+else
+  fail "a status outside {unstable,testing,stable,archaic} is caught" \
+       "check did not fail on an invented status value: $OUT"
+fi
+
+# ── 4. Negative control: owl:deprecated disagreeing with term_status ──────────
+# Two machine-readable maturity signals that contradict each other are worse
+# than one, so the pairing is enforced rather than assumed.
+cp "$SPEC_ROOT/ontologies/evidence/v1-draft/evidence.ttl" "$WORK/deprecated.ttl"
+sed 's/vs:term_status "archaic"/vs:term_status "stable"/' \
+    "$SPEC_ROOT/ontologies/evidence/v1-draft/evidence.ttl" > "$WORK/deprecated.ttl"
+OUT="$("$PYTHON" "$CHECK" "$WORK/deprecated.ttl" 2>&1)"
+if [ $? -ne 0 ] && echo "$OUT" | grep -q "owl:deprecated but term_status"; then
+  pass "owl:deprecated with a non-archaic status is caught"
+else
+  fail "owl:deprecated with a non-archaic status is caught" \
+       "check did not fail on a deprecated term marked stable: $OUT"
+fi
+
+# ── 5. Non-vacuity: nothing to check must not read as success ─────────────────
+cat > "$WORK/empty.ttl" <<'TTL'
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+<https://ns.cascadeprotocol.org/nothing/v1#> a owl:Ontology ;
+    dct:title "No terms at all" .
+TTL
+OUT="$("$PYTHON" "$CHECK" "$WORK/empty.ttl" 2>&1)"
+if echo "$OUT" | grep -q "   0 terms"; then
+  pass "a corpus with no terms is reported as examining nothing"
+else
+  fail "a corpus with no terms is reported as examining nothing" \
+       "expected a zero-term report: $OUT"
+fi
+
+echo ""
+echo "passed: $PASSED   failed: $FAILED"
+[ "$FAILED" -eq 0 ] || exit 1


### PR DESCRIPTION
## What

All 411 terms across the five draft vocabularies (advisory, diabetes, evidence, genomics, workbench) now declare `vs:term_status`.

Cascade stated vocabulary maturity **once per vocabulary, in prose**: an ontology-level `owl:versionInfo "1.0-draft"` and an `rdfs:comment` saying the vocabulary may change. A consumer could not tell a settled term from one authored last week, so the only safe reading of a draft vocabulary was to treat all of it as provisional.

The convention already exists and is not ours. [W3C SemWeb Vocabulary Status](http://www.w3.org/2003/06/sw-vocab-status/ns#), originating in FOAF, defines `vs:term_status` with values `unstable` / `testing` / `stable` / `archaic`. Its own description gives the design reason for the granularity: indicating status at the term level rather than the vocabulary level makes fine-grained improvement easier. That is exactly what a `/v1#` namespace promises — the vocabulary evolves in place and a term is promoted without minting a new namespace. This repository already used the matching standard at the other end of the lifecycle, `owl:deprecated`, 21 times.

Draft terms are `unstable`; the five already marked `owl:deprecated` are `archaic`.

**The point is that it can stop being uniform.** A blanket `unstable` carries no more information than the prose it replaces. What it buys is the mechanism: promoting one term to `testing` is now a one-triple change a consumer can query, rather than a graduation event for a whole vocabulary.

`owl:versionInfo` remains the vocabulary-level draft marker, unchanged in meaning. Where both signals speak they must agree, so a term marked `owl:deprecated` must be `archaic` — enforced, because two machine-readable maturity claims that contradict each other are worse than one.

## Verification

Nothing but the status triples changed, and this is proven rather than asserted: the parsed N-Triples of every file were diffed before and after, with blank-node labels normalised.

| Vocabulary | Terms | Status triples added | Other additions | Removed |
|---|---|---|---|---|
| advisory | 51 | +51 | 0 | 0 |
| diabetes | 108 | +108 | 0 | 0 |
| evidence | 54 | +54 | 0 | 0 |
| genomics | 136 | +136 | 0 | 0 |
| workbench | 62 | +62 | 0 | 0 |

Counts corroborated by two independent parsers (Jena `riot` and rdflib 7.6.0).

## Gated, with negative controls

The pass that added these annotations **silently skipped 96 of 411 terms** — every term that happened to be preceded by a section comment — and reported success. It was caught by auditing the parsed graph, never by the inserter's own count. A tool's report of what it did is not evidence that it did it.

So `scripts/check-term-status.py` reads the graph, and `scripts/test-check-term-status.sh` reintroduces each defect into scratch copies and requires the check to fail *and name the term*:

- a term with no `vs:term_status`
- an invented status value outside the four
- `owl:deprecated` disagreeing with `term_status`
- a corpus with no terms at all, where reporting PASS rather than "0 terms examined" would be the vacuous-check failure

Wired into CI on `ontologies/**`, following the existing `shapes.yml` pattern.

## Also fixed

Three `rdfs:seeAlso` IRIs that had been returning 404 since the documentation paths were renamed: advisory pointed at `/docs/advisory/v1.0-draft/`, diabetes at `/docs/diabetes/v1.0-draft/`, genomics at `/docs/genomics/v1/`. All five drafts now point at their published `/docs/{vocab}/v1-draft/` page.

## Versions

advisory 1.0-draft.0.2, diabetes 1.0-draft.0.2, evidence 1.0-draft.0.3, genomics 1.0-draft.0.5, workbench 1.0-draft.0.7. None of these is registered in `VOCAB_VERSIONS`, so no downstream version registry changes.

## Sequence

This is step 1. Downstream syncs are prepared and should merge after it:
- `cascade-cli` — vendored shapes re-synced (step 4)
- `cascadeprotocol.org` — docs and LLM reference (step 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)